### PR TITLE
docs: add instructions for handling sqlite3 build scripts

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -8,6 +8,16 @@ A backend service built with [Nest](https://github.com/nestjs/nest) to facilitat
 
 ```bash
 $ pnpm install
+
+# IMPORTANT Run sqlite3 postcript install
+
+# Option 1 (recommended):
+# BE SURE TO USE ARROW KEYS AND SPACE BAR TO SELECT THE SQLITE3 OPTION
+# BEFORE TO PRESS ENTER
+$ pnpm approve-builds
+
+# Option 2
+$ cd node_modules/sqlite3/ && pnpm rebuild & cd ../..
 ```
 
 ## Compile and run the project


### PR DESCRIPTION
- Add important note about running sqlite3 postcript install
- Document two options for allowing build scripts:
  1. Using pnpm approve-builds (recommended)
  2. Manual rebuild in sqlite3 directory
- Addresses pnpm security warnings for ignored build scripts