### PR TITLE
Security/jwt contributor identity derivation

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -20,6 +20,7 @@ lerna-debug.log*
 /coverage
 /.nyc_output
 /.downloads
+/test/.e2e-db
 
 # IDEs and editors
 /.idea

--- a/apps/backend/src/storage/storage.controller.spec.ts
+++ b/apps/backend/src/storage/storage.controller.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthenticatedRequest, JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { StorageController } from './storage.controller';
@@ -85,17 +84,18 @@ describe('StorageController', () => {
   });
 
   describe('startMultipartUpload', () => {
-    it('should call storageService.startMultipartUpload with data, ceremonyId, and userId', async () => {
+    it('should call storageService.startMultipartUpload with data, ceremonyId, and authenticated user id', async () => {
       const ceremonyId = 1;
       const userId = 1;
       const data: ObjectKeyDto = { objectKey: 'test-key' };
-      await controller.startMultipartUpload(ceremonyId, userId, data);
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.startMultipartUpload(req, ceremonyId, data);
       expect(storageService.startMultipartUpload).toHaveBeenCalledWith(data, ceremonyId, userId);
     });
   });
 
   describe('generatePreSignedUrlsParts', () => {
-    it('should call storageService.generatePreSignedUrlsParts with data, ceremonyId, and userId', async () => {
+    it('should call storageService.generatePreSignedUrlsParts with data, ceremonyId, and authenticated user id', async () => {
       const ceremonyId = 1;
       const userId = 1;
       const data: GeneratePreSignedUrlsPartsData = {
@@ -103,7 +103,8 @@ describe('StorageController', () => {
         uploadId: 'test-upload-id',
         numberOfParts: 3,
       };
-      await controller.generatePreSignedUrlsParts(ceremonyId, userId, data);
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.generatePreSignedUrlsParts(req, ceremonyId, data);
       expect(storageService.generatePreSignedUrlsParts).toHaveBeenCalledWith(
         data,
         ceremonyId,
@@ -113,7 +114,7 @@ describe('StorageController', () => {
   });
 
   describe('completeMultipartUpload', () => {
-    it('should call storageService.completeMultipartUpload with data, ceremonyId, and userId', async () => {
+    it('should call storageService.completeMultipartUpload with data, ceremonyId, and authenticated user id', async () => {
       const ceremonyId = 1;
       const userId = 1;
       const data: CompleteMultiPartUploadData = {
@@ -121,58 +122,37 @@ describe('StorageController', () => {
         uploadId: 'test-upload-id',
         parts: [],
       };
-      await controller.completeMultipartUpload(ceremonyId, userId, data);
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.completeMultipartUpload(req, ceremonyId, data);
       expect(storageService.completeMultipartUpload).toHaveBeenCalledWith(data, ceremonyId, userId);
     });
   });
 
   describe('temporaryStoreMultipartUploadId', () => {
-    it('should call storageService.temporaryStoreCurrentContributionMultiPartUploadId when user matches', async () => {
+    it('should call storageService.temporaryStoreCurrentContributionMultiPartUploadId with the authenticated user id', async () => {
       const ceremonyId = 1;
       const userId = 1;
       const data: UploadIdDto = { uploadId: 'mpu-id' };
       const req = { user: { id: userId } } as AuthenticatedRequest;
-      await controller.temporaryStoreMultipartUploadId(req, ceremonyId, userId, data);
+      await controller.temporaryStoreMultipartUploadId(req, ceremonyId, data);
       expect(
         storageService.temporaryStoreCurrentContributionMultiPartUploadId,
       ).toHaveBeenCalledWith(data, ceremonyId, userId);
     });
-
-    it('should reject when query userId does not match JWT user', () => {
-      const req = { user: { id: 2 } } as AuthenticatedRequest;
-      expect(() =>
-        controller.temporaryStoreMultipartUploadId(req, 1, 1, { uploadId: 'x' }),
-      ).toThrow(ForbiddenException);
-      expect(
-        storageService.temporaryStoreCurrentContributionMultiPartUploadId,
-      ).not.toHaveBeenCalled();
-    });
   });
 
   describe('temporaryStoreUploadedChunkData', () => {
-    it('should call storageService.temporaryStoreCurrentContributionUploadedChunkData when user matches', async () => {
+    it('should call storageService.temporaryStoreCurrentContributionUploadedChunkData with the authenticated user id', async () => {
       const ceremonyId = 1;
       const userId = 1;
       const data: TemporaryStoreCurrentContributionUploadedChunkData = {
         chunk: { ETag: '"e1"', PartNumber: 1 },
       };
       const req = { user: { id: userId } } as AuthenticatedRequest;
-      await controller.temporaryStoreUploadedChunkData(req, ceremonyId, userId, data);
+      await controller.temporaryStoreUploadedChunkData(req, ceremonyId, data);
       expect(
         storageService.temporaryStoreCurrentContributionUploadedChunkData,
       ).toHaveBeenCalledWith(data, ceremonyId, userId);
-    });
-
-    it('should reject when query userId does not match JWT user', () => {
-      const req = { user: { id: 99 } } as AuthenticatedRequest;
-      expect(() =>
-        controller.temporaryStoreUploadedChunkData(req, 1, 1, {
-          chunk: { ETag: '"e1"', PartNumber: 1 },
-        }),
-      ).toThrow(ForbiddenException);
-      expect(
-        storageService.temporaryStoreCurrentContributionUploadedChunkData,
-      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/storage/storage.controller.spec.ts
+++ b/apps/backend/src/storage/storage.controller.spec.ts
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import { ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthenticatedRequest, JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { StorageController } from './storage.controller';
 import { StorageService } from './storage.service';
 import {
   ObjectKeyDto,
   GeneratePreSignedUrlsPartsData,
   CompleteMultiPartUploadData,
+  TemporaryStoreCurrentContributionUploadedChunkData,
+  UploadIdDto,
 } from './dto/storage-dto';
 
 describe('StorageController', () => {
@@ -21,6 +25,8 @@ describe('StorageController', () => {
       startMultipartUpload: jest.fn().mockResolvedValue({}),
       generatePreSignedUrlsParts: jest.fn().mockResolvedValue({}),
       completeMultipartUpload: jest.fn().mockResolvedValue({}),
+      temporaryStoreCurrentContributionMultiPartUploadId: jest.fn().mockResolvedValue(undefined),
+      temporaryStoreCurrentContributionUploadedChunkData: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -31,7 +37,10 @@ describe('StorageController', () => {
           useValue: mockStorageService,
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
 
     controller = module.get<StorageController>(StorageController);
     storageService = module.get<StorageService>(StorageService) as jest.Mocked<StorageService>;
@@ -114,6 +123,56 @@ describe('StorageController', () => {
       };
       await controller.completeMultipartUpload(ceremonyId, userId, data);
       expect(storageService.completeMultipartUpload).toHaveBeenCalledWith(data, ceremonyId, userId);
+    });
+  });
+
+  describe('temporaryStoreMultipartUploadId', () => {
+    it('should call storageService.temporaryStoreCurrentContributionMultiPartUploadId when user matches', async () => {
+      const ceremonyId = 1;
+      const userId = 1;
+      const data: UploadIdDto = { uploadId: 'mpu-id' };
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.temporaryStoreMultipartUploadId(req, ceremonyId, userId, data);
+      expect(
+        storageService.temporaryStoreCurrentContributionMultiPartUploadId,
+      ).toHaveBeenCalledWith(data, ceremonyId, userId);
+    });
+
+    it('should reject when query userId does not match JWT user', () => {
+      const req = { user: { id: 2 } } as AuthenticatedRequest;
+      expect(() =>
+        controller.temporaryStoreMultipartUploadId(req, 1, 1, { uploadId: 'x' }),
+      ).toThrow(ForbiddenException);
+      expect(
+        storageService.temporaryStoreCurrentContributionMultiPartUploadId,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('temporaryStoreUploadedChunkData', () => {
+    it('should call storageService.temporaryStoreCurrentContributionUploadedChunkData when user matches', async () => {
+      const ceremonyId = 1;
+      const userId = 1;
+      const data: TemporaryStoreCurrentContributionUploadedChunkData = {
+        chunk: { ETag: '"e1"', PartNumber: 1 },
+      };
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.temporaryStoreUploadedChunkData(req, ceremonyId, userId, data);
+      expect(
+        storageService.temporaryStoreCurrentContributionUploadedChunkData,
+      ).toHaveBeenCalledWith(data, ceremonyId, userId);
+    });
+
+    it('should reject when query userId does not match JWT user', () => {
+      const req = { user: { id: 99 } } as AuthenticatedRequest;
+      expect(() =>
+        controller.temporaryStoreUploadedChunkData(req, 1, 1, {
+          chunk: { ETag: '"e1"', PartNumber: 1 },
+        }),
+      ).toThrow(ForbiddenException);
+      expect(
+        storageService.temporaryStoreCurrentContributionUploadedChunkData,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/storage/storage.controller.spec.ts
+++ b/apps/backend/src/storage/storage.controller.spec.ts
@@ -89,8 +89,17 @@ describe('StorageController', () => {
       const ceremonyId = 1;
       const userId = 1;
       const data: ObjectKeyDto = { objectKey: 'test-key' };
-      await controller.startMultipartUpload(ceremonyId, userId, data);
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.startMultipartUpload(req, ceremonyId, userId, data);
       expect(storageService.startMultipartUpload).toHaveBeenCalledWith(data, ceremonyId, userId);
+    });
+
+    it('should reject when query userId does not match JWT user', () => {
+      const req = { user: { id: 2 } } as AuthenticatedRequest;
+      expect(() => controller.startMultipartUpload(req, 1, 1, { objectKey: 'test-key' })).toThrow(
+        ForbiddenException,
+      );
+      expect(storageService.startMultipartUpload).not.toHaveBeenCalled();
     });
   });
 
@@ -103,12 +112,25 @@ describe('StorageController', () => {
         uploadId: 'test-upload-id',
         numberOfParts: 3,
       };
-      await controller.generatePreSignedUrlsParts(ceremonyId, userId, data);
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.generatePreSignedUrlsParts(req, ceremonyId, userId, data);
       expect(storageService.generatePreSignedUrlsParts).toHaveBeenCalledWith(
         data,
         ceremonyId,
         userId,
       );
+    });
+
+    it('should reject when query userId does not match JWT user', () => {
+      const req = { user: { id: 2 } } as AuthenticatedRequest;
+      expect(() =>
+        controller.generatePreSignedUrlsParts(req, 1, 1, {
+          objectKey: 'test-key',
+          uploadId: 'test-upload-id',
+          numberOfParts: 3,
+        }),
+      ).toThrow(ForbiddenException);
+      expect(storageService.generatePreSignedUrlsParts).not.toHaveBeenCalled();
     });
   });
 
@@ -121,8 +143,21 @@ describe('StorageController', () => {
         uploadId: 'test-upload-id',
         parts: [],
       };
-      await controller.completeMultipartUpload(ceremonyId, userId, data);
+      const req = { user: { id: userId } } as AuthenticatedRequest;
+      await controller.completeMultipartUpload(req, ceremonyId, userId, data);
       expect(storageService.completeMultipartUpload).toHaveBeenCalledWith(data, ceremonyId, userId);
+    });
+
+    it('should reject when query userId does not match JWT user', () => {
+      const req = { user: { id: 2 } } as AuthenticatedRequest;
+      expect(() =>
+        controller.completeMultipartUpload(req, 1, 1, {
+          objectKey: 'test-key',
+          uploadId: 'test-upload-id',
+          parts: [],
+        }),
+      ).toThrow(ForbiddenException);
+      expect(storageService.completeMultipartUpload).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/storage/storage.controller.ts
+++ b/apps/backend/src/storage/storage.controller.ts
@@ -26,10 +26,13 @@ import {
   UploadIdDto,
 } from './dto/storage-dto';
 
-function assertQueryUserIdMatchesAuth(req: AuthenticatedRequest, userId: number): void {
-  if (req.user?.id !== userId) {
-    throw new ForbiddenException();
+function getAuthenticatedUserId(req: AuthenticatedRequest): number {
+  const userId = req.user?.id;
+  if (userId === undefined) {
+    throw new ForbiddenException('User not authenticated');
   }
+
+  return userId;
 }
 
 @ApiTags('storage')
@@ -86,51 +89,65 @@ export class StorageController {
   }
 
   @ApiOperation({ summary: 'Start multipart upload for large files' })
+  @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
   @ApiBody({ type: ObjectKeyDto, description: 'Object key information' })
   @ApiResponse({ status: 200, description: 'Multipart upload started successfully.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
   @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @UseGuards(JwtAuthGuard)
   @Post('multipart/start')
   startMultipartUpload(
+    @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
-    @Query('userId') userId: number,
     @Body() data: ObjectKeyDto,
   ) {
-    return this.storageService.startMultipartUpload(data, ceremonyId, userId);
+    return this.storageService.startMultipartUpload(data, ceremonyId, getAuthenticatedUserId(req));
   }
 
   @ApiOperation({ summary: 'Generate pre-signed URLs for multipart upload parts' })
+  @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
   @ApiBody({ type: GeneratePreSignedUrlsPartsData, description: 'Multipart upload parts data' })
   @ApiResponse({ status: 200, description: 'Return pre-signed URLs for upload parts.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
   @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @UseGuards(JwtAuthGuard)
   @Post('multipart/urls')
   generatePreSignedUrlsParts(
+    @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
-    @Query('userId') userId: number,
     @Body() data: GeneratePreSignedUrlsPartsData,
   ) {
-    return this.storageService.generatePreSignedUrlsParts(data, ceremonyId, userId);
+    return this.storageService.generatePreSignedUrlsParts(
+      data,
+      ceremonyId,
+      getAuthenticatedUserId(req),
+    );
   }
 
   @ApiOperation({ summary: 'Complete multipart upload' })
+  @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
   @ApiBody({ type: CompleteMultiPartUploadData, description: 'Complete multipart upload data' })
   @ApiResponse({ status: 200, description: 'Multipart upload completed successfully.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
   @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @UseGuards(JwtAuthGuard)
   @Post('multipart/complete')
   completeMultipartUpload(
+    @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
-    @Query('userId') userId: number,
     @Body() data: CompleteMultiPartUploadData,
   ) {
-    return this.storageService.completeMultipartUpload(data, ceremonyId, userId);
+    return this.storageService.completeMultipartUpload(
+      data,
+      ceremonyId,
+      getAuthenticatedUserId(req),
+    );
   }
 
   @ApiOperation({
@@ -139,10 +156,10 @@ export class StorageController {
   })
   @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
   @ApiBody({ type: UploadIdDto, description: 'S3 multipart upload id' })
   @ApiResponse({ status: 200, description: 'Temporary upload id stored.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
   @ApiResponse({ status: 403, description: 'Forbidden.' })
   @ApiResponse({ status: 404, description: 'Ceremony or participant not found.' })
   @UseGuards(JwtAuthGuard)
@@ -150,14 +167,12 @@ export class StorageController {
   temporaryStoreMultipartUploadId(
     @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
-    @Query('userId') userId: number,
     @Body() data: UploadIdDto,
   ) {
-    assertQueryUserIdMatchesAuth(req, userId);
     return this.storageService.temporaryStoreCurrentContributionMultiPartUploadId(
       data,
       ceremonyId,
-      userId,
+      getAuthenticatedUserId(req),
     );
   }
 
@@ -167,10 +182,10 @@ export class StorageController {
   })
   @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
   @ApiBody({ type: TemporaryStoreCurrentContributionUploadedChunkData, description: 'Chunk data' })
   @ApiResponse({ status: 200, description: 'Chunk metadata stored.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
   @ApiResponse({ status: 403, description: 'Forbidden.' })
   @ApiResponse({ status: 404, description: 'Ceremony or participant not found.' })
   @UseGuards(JwtAuthGuard)
@@ -178,14 +193,12 @@ export class StorageController {
   temporaryStoreUploadedChunkData(
     @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
-    @Query('userId') userId: number,
     @Body() data: TemporaryStoreCurrentContributionUploadedChunkData,
   ) {
-    assertQueryUserIdMatchesAuth(req, userId);
     return this.storageService.temporaryStoreCurrentContributionUploadedChunkData(
       data,
       ceremonyId,
-      userId,
+      getAuthenticatedUserId(req),
     );
   }
 }

--- a/apps/backend/src/storage/storage.controller.ts
+++ b/apps/backend/src/storage/storage.controller.ts
@@ -1,11 +1,36 @@
-import { Body, Controller, Post, Delete, Query } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiResponse, ApiTags, ApiBody } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Post,
+  Delete,
+  Query,
+  UseGuards,
+  Request,
+  ForbiddenException,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+  ApiBody,
+} from '@nestjs/swagger';
+import { AuthenticatedRequest, JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { StorageService } from './storage.service';
 import {
   CompleteMultiPartUploadData,
   GeneratePreSignedUrlsPartsData,
   ObjectKeyDto,
+  TemporaryStoreCurrentContributionUploadedChunkData,
+  UploadIdDto,
 } from './dto/storage-dto';
+
+function assertQueryUserIdMatchesAuth(req: AuthenticatedRequest, userId: number): void {
+  if (req.user?.id !== userId) {
+    throw new ForbiddenException();
+  }
+}
 
 @ApiTags('storage')
 @Controller('storage')
@@ -106,5 +131,61 @@ export class StorageController {
     @Body() data: CompleteMultiPartUploadData,
   ) {
     return this.storageService.completeMultipartUpload(data, ceremonyId, userId);
+  }
+
+  @ApiOperation({
+    summary:
+      'Store multipart upload id for resumable contribution upload (actions client contract)',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
+  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiBody({ type: UploadIdDto, description: 'S3 multipart upload id' })
+  @ApiResponse({ status: 200, description: 'Temporary upload id stored.' })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  @ApiResponse({ status: 404, description: 'Ceremony or participant not found.' })
+  @UseGuards(JwtAuthGuard)
+  @Post('temporary-store-current-contribution-multipart-upload-id')
+  temporaryStoreMultipartUploadId(
+    @Request() req: AuthenticatedRequest,
+    @Query('id') ceremonyId: number,
+    @Query('userId') userId: number,
+    @Body() data: UploadIdDto,
+  ) {
+    assertQueryUserIdMatchesAuth(req, userId);
+    return this.storageService.temporaryStoreCurrentContributionMultiPartUploadId(
+      data,
+      ceremonyId,
+      userId,
+    );
+  }
+
+  @ApiOperation({
+    summary:
+      'Append uploaded chunk ETag/part for resumable contribution upload (actions client contract)',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
+  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiBody({ type: TemporaryStoreCurrentContributionUploadedChunkData, description: 'Chunk data' })
+  @ApiResponse({ status: 200, description: 'Chunk metadata stored.' })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  @ApiResponse({ status: 404, description: 'Ceremony or participant not found.' })
+  @UseGuards(JwtAuthGuard)
+  @Post('temporary-store-current-contribution-uploaded-chunk-data')
+  temporaryStoreUploadedChunkData(
+    @Request() req: AuthenticatedRequest,
+    @Query('id') ceremonyId: number,
+    @Query('userId') userId: number,
+    @Body() data: TemporaryStoreCurrentContributionUploadedChunkData,
+  ) {
+    assertQueryUserIdMatchesAuth(req, userId);
+    return this.storageService.temporaryStoreCurrentContributionUploadedChunkData(
+      data,
+      ceremonyId,
+      userId,
+    );
   }
 }

--- a/apps/backend/src/storage/storage.controller.ts
+++ b/apps/backend/src/storage/storage.controller.ts
@@ -28,7 +28,7 @@ import {
 
 function assertQueryUserIdMatchesAuth(req: AuthenticatedRequest, userId: number): void {
   if (req.user?.id !== userId) {
-    throw new ForbiddenException();
+    throw new ForbiddenException('Authenticated user does not match the requested userId');
   }
 }
 
@@ -86,50 +86,65 @@ export class StorageController {
   }
 
   @ApiOperation({ summary: 'Start multipart upload for large files' })
+  @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiQuery({ name: 'userId', type: 'number', description: 'User ID' })
   @ApiBody({ type: ObjectKeyDto, description: 'Object key information' })
   @ApiResponse({ status: 200, description: 'Multipart upload started successfully.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
   @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @UseGuards(JwtAuthGuard)
   @Post('multipart/start')
   startMultipartUpload(
+    @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
     @Query('userId') userId: number,
     @Body() data: ObjectKeyDto,
   ) {
+    assertQueryUserIdMatchesAuth(req, userId);
     return this.storageService.startMultipartUpload(data, ceremonyId, userId);
   }
 
   @ApiOperation({ summary: 'Generate pre-signed URLs for multipart upload parts' })
+  @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiQuery({ name: 'userId', type: 'number', description: 'User ID' })
   @ApiBody({ type: GeneratePreSignedUrlsPartsData, description: 'Multipart upload parts data' })
   @ApiResponse({ status: 200, description: 'Return pre-signed URLs for upload parts.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
   @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @UseGuards(JwtAuthGuard)
   @Post('multipart/urls')
   generatePreSignedUrlsParts(
+    @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
     @Query('userId') userId: number,
     @Body() data: GeneratePreSignedUrlsPartsData,
   ) {
+    assertQueryUserIdMatchesAuth(req, userId);
     return this.storageService.generatePreSignedUrlsParts(data, ceremonyId, userId);
   }
 
   @ApiOperation({ summary: 'Complete multipart upload' })
+  @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiQuery({ name: 'userId', type: 'number', description: 'User ID' })
   @ApiBody({ type: CompleteMultiPartUploadData, description: 'Complete multipart upload data' })
   @ApiResponse({ status: 200, description: 'Multipart upload completed successfully.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
   @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @UseGuards(JwtAuthGuard)
   @Post('multipart/complete')
   completeMultipartUpload(
+    @Request() req: AuthenticatedRequest,
     @Query('id') ceremonyId: number,
     @Query('userId') userId: number,
     @Body() data: CompleteMultiPartUploadData,
   ) {
+    assertQueryUserIdMatchesAuth(req, userId);
     return this.storageService.completeMultipartUpload(data, ceremonyId, userId);
   }
 
@@ -139,7 +154,7 @@ export class StorageController {
   })
   @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiQuery({ name: 'userId', type: 'number', description: 'User ID' })
   @ApiBody({ type: UploadIdDto, description: 'S3 multipart upload id' })
   @ApiResponse({ status: 200, description: 'Temporary upload id stored.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
@@ -167,7 +182,7 @@ export class StorageController {
   })
   @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'id', type: 'number', description: 'Ceremony ID' })
-  @ApiQuery({ name: 'userId', type: 'string', description: 'User ID' })
+  @ApiQuery({ name: 'userId', type: 'number', description: 'User ID' })
   @ApiBody({ type: TemporaryStoreCurrentContributionUploadedChunkData, description: 'Chunk data' })
   @ApiResponse({ status: 200, description: 'Chunk metadata stored.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })

--- a/apps/backend/src/storage/storage.module.ts
+++ b/apps/backend/src/storage/storage.module.ts
@@ -1,13 +1,19 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { StorageController } from './storage.controller';
 import { StorageService } from './storage.service';
+import { AuthModule } from '../auth/auth.module';
 import { CeremoniesModule } from '../ceremonies/ceremonies.module';
 import { ParticipantsModule } from '../participants/participants.module';
 import { UsersModule } from '../users/users.module';
 
 @Module({
   controllers: [StorageController],
-  imports: [forwardRef(() => CeremoniesModule), forwardRef(() => ParticipantsModule), UsersModule],
+  imports: [
+    AuthModule,
+    forwardRef(() => CeremoniesModule),
+    forwardRef(() => ParticipantsModule),
+    UsersModule,
+  ],
   providers: [StorageService],
   exports: [StorageService],
 })

--- a/apps/backend/src/storage/storage.service.spec.ts
+++ b/apps/backend/src/storage/storage.service.spec.ts
@@ -73,6 +73,8 @@ describe('StorageService', () => {
     const mockParticipantsService = {
       findAll: jest.fn(),
       findByUserIdAndCeremonyId: jest.fn(),
+      checkPreConditionForCurrentContributorToInteractWithMultiPartUpload: jest.fn(),
+      checkUploadingFileValidity: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -263,6 +265,94 @@ describe('StorageService', () => {
       await expect(service.completeMultipartUpload(mockData, 1, 1)).rejects.toThrow(
         InternalServerErrorException,
       );
+    });
+  });
+
+  describe('temporaryStoreCurrentContributionMultiPartUploadId', () => {
+    it('should persist upload id for an uploading participant', async () => {
+      const update = jest.fn().mockResolvedValue(undefined);
+      participantsService.findByUserIdAndCeremonyId.mockResolvedValue({
+        ...mockParticipant,
+        update,
+      } as never);
+      ceremoniesService.isCoordinator.mockResolvedValue({ isCoordinator: false } as never);
+
+      await service.temporaryStoreCurrentContributionMultiPartUploadId(
+        { uploadId: 'upload-123' },
+        1,
+        7,
+      );
+
+      expect(participantsService.findByUserIdAndCeremonyId).toHaveBeenCalledWith(7, 1);
+      expect(update).toHaveBeenCalledWith({
+        tempContributionData: {
+          uploadId: 'upload-123',
+        },
+      });
+    });
+
+    it('should allow coordinator override outside UPLOADING step', async () => {
+      const update = jest.fn().mockResolvedValue(undefined);
+      participantsService.findByUserIdAndCeremonyId.mockResolvedValue({
+        ...mockParticipant,
+        contributionStep: ParticipantContributionStep.DOWNLOADING,
+        update,
+      } as never);
+      ceremoniesService.isCoordinator.mockResolvedValue({ isCoordinator: true } as never);
+
+      await expect(
+        service.temporaryStoreCurrentContributionMultiPartUploadId(
+          { uploadId: 'upload-123' },
+          1,
+          7,
+        ),
+      ).resolves.toBeUndefined();
+      expect(update).toHaveBeenCalled();
+    });
+  });
+
+  describe('temporaryStoreCurrentContributionUploadedChunkData', () => {
+    it('should append chunk metadata for an uploading participant', async () => {
+      const update = jest.fn().mockResolvedValue(undefined);
+      participantsService.findByUserIdAndCeremonyId.mockResolvedValue({
+        ...mockParticipant,
+        tempContributionData: { uploadId: 'upload-123', chunks: [] },
+        update,
+      } as never);
+      ceremoniesService.isCoordinator.mockResolvedValue({ isCoordinator: false } as never);
+
+      await service.temporaryStoreCurrentContributionUploadedChunkData(
+        { chunk: { ETag: '"etag-1"', PartNumber: 1 } },
+        1,
+        7,
+      );
+
+      expect(update).toHaveBeenCalledWith({
+        tempContributionData: {
+          uploadId: 'upload-123',
+          chunks: [{ ETag: '"etag-1"', PartNumber: 1 }],
+        },
+      });
+    });
+
+    it('should allow coordinator override when participant is not uploading', async () => {
+      const update = jest.fn().mockResolvedValue(undefined);
+      participantsService.findByUserIdAndCeremonyId.mockResolvedValue({
+        ...mockParticipant,
+        contributionStep: ParticipantContributionStep.COMPUTING,
+        tempContributionData: { chunks: [] },
+        update,
+      } as never);
+      ceremoniesService.isCoordinator.mockResolvedValue({ isCoordinator: true } as never);
+
+      await expect(
+        service.temporaryStoreCurrentContributionUploadedChunkData(
+          { chunk: { ETag: '"etag-2"', PartNumber: 2 } },
+          1,
+          7,
+        ),
+      ).resolves.toBeUndefined();
+      expect(update).toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/test/coordinator.e2e-spec.ts
+++ b/apps/backend/test/coordinator.e2e-spec.ts
@@ -262,6 +262,53 @@ describe('Coordinator (e2e)', () => {
     expect(savedParticipant.contributionStep).toBe(ParticipantContributionStep.DOWNLOADING);
   });
 
+  it('should accept storage temporary-state endpoints matching @brebaje/actions multipart contract', async () => {
+    const uploadId = 'e2e-test-multipart-upload-id';
+    const mpuUrl = new URL(
+      `${TEST_URL}/storage/temporary-store-current-contribution-multipart-upload-id`,
+    );
+    mpuUrl.searchParams.set('id', String(ceremonyId));
+    mpuUrl.searchParams.set('userId', String(coordinatorId));
+
+    const mpuResponse = await fetch(mpuUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwtToken}`,
+      },
+      body: JSON.stringify({ uploadId }),
+    });
+    expect(mpuResponse.status).toBe(200);
+
+    const chunkUrl = new URL(
+      `${TEST_URL}/storage/temporary-store-current-contribution-uploaded-chunk-data`,
+    );
+    chunkUrl.searchParams.set('id', String(ceremonyId));
+    chunkUrl.searchParams.set('userId', String(coordinatorId));
+
+    const chunkPayload = { chunk: { ETag: '"e2e-etag"', PartNumber: 1 } };
+    const chunkResponse = await fetch(chunkUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwtToken}`,
+      },
+      body: JSON.stringify(chunkPayload),
+    });
+    expect(chunkResponse.status).toBe(200);
+
+    const participantRow = await Participant.findOne({
+      where: { userId: coordinatorId, ceremonyId },
+    });
+    if (!participantRow) {
+      throw new Error('Expected participant row after temporary store calls');
+    }
+    const temp = participantRow.tempContributionData;
+    expect(temp).toBeDefined();
+    expect(temp?.uploadId).toBe(uploadId);
+    expect(temp?.chunks).toEqual([chunkPayload.chunk]);
+  });
+
   it(
     'should upload the circuit artifacts to the bucket',
     async () => {

--- a/apps/backend/test/coordinator.e2e-spec.ts
+++ b/apps/backend/test/coordinator.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { App } from 'supertest/types';
+import { Op } from 'sequelize';
 import { AppModule } from '../src/app.module';
 import { configureApp } from '../src/app.config';
 import { AWS_CEREMONY_BUCKET_POSTFIX, PORT } from 'src/utils/constants';
@@ -8,6 +9,7 @@ import { ceremonyDto, circuits, coordinatorDto, projectDto } from './constants';
 import { User } from 'src/users/user.model';
 import { Ceremony } from 'src/ceremonies/ceremony.model';
 import { Project } from 'src/projects/project.model';
+import { Contribution } from 'src/contributions/contribution.model';
 import {
   getBucketName,
   sanitizeString,
@@ -33,9 +35,14 @@ const circuitArtifactHashes: Record<
   { pot: string; r1cs: string; wasm: string; zkey: string }
 > = {};
 
-// pass the Nest SQLite models to the database in /.db/data.sqlite3
-process.env.DB_SQLITE_SYNCHRONIZE = 'true';
+// DB_SQLITE_SYNCHRONIZE and DB path: see test/e2e-env.setup.ts (must run before AppModule import eval).
 process.env.API_URL = TEST_URL;
+
+const awsIntegrationEnabled = Boolean(
+  process.env.AWS_ACCESS_KEY_ID?.trim() && process.env.AWS_SECRET_ACCESS_KEY?.trim(),
+);
+/** S3-backed steps; skipped when AWS credentials are not configured (local/CI). */
+const awsIt = awsIntegrationEnabled ? it : it.skip;
 
 describe('Coordinator (e2e)', () => {
   let app: INestApplication<App>;
@@ -62,13 +69,31 @@ describe('Coordinator (e2e)', () => {
   });
 
   afterAll(async () => {
-    await Promise.all([
-      Participant.destroy({ where: { id: ceremonyId || '' } }),
-      Ceremony.destroy({ where: { id: ceremonyId || '' } }),
-      Project.destroy({ where: { id: projectId || '' } }),
-      User.destroy({ where: { id: coordinatorId || '' } }),
-      app.close(),
-    ]);
+    try {
+      if (ceremonyId != null) {
+        const participants = await Participant.findAll({
+          where: { ceremonyId },
+          attributes: ['id'],
+        });
+        const participantIds = participants.map((p) => p.id);
+        if (participantIds.length > 0) {
+          await Contribution.destroy({
+            where: { participantId: { [Op.in]: participantIds } },
+          });
+        }
+        await Circuit.destroy({ where: { ceremonyId } });
+        await Participant.destroy({ where: { ceremonyId } });
+        await Ceremony.destroy({ where: { id: ceremonyId } });
+      }
+      if (projectId != null) {
+        await Project.destroy({ where: { id: projectId } });
+      }
+      if (coordinatorId != null) {
+        await User.destroy({ where: { id: coordinatorId } });
+      }
+    } finally {
+      await app?.close();
+    }
   });
 
   it('should create a new user', async () => {
@@ -209,24 +234,28 @@ describe('Coordinator (e2e)', () => {
     ceremonyId = body.id;
   });
 
-  it('should create a bucket in S3', async () => {
-    const url = new URL('/storage/bucket', TEST_URL);
-    url.searchParams.set('id', String(ceremonyId));
+  awsIt(
+    'should create a bucket in S3',
+    async () => {
+      const url = new URL('/storage/bucket', TEST_URL);
+      url.searchParams.set('id', String(ceremonyId));
 
-    const response = await fetch(url, {
-      method: 'POST',
-    });
+      const response = await fetch(url, {
+        method: 'POST',
+      });
 
-    const body = (await response.json()) as { bucketName: string };
+      const body = (await response.json()) as { bucketName: string };
 
-    const expectedBucketName = getBucketName(
-      AWS_CEREMONY_BUCKET_POSTFIX,
-      projectDto.name,
-      ceremonyDto.description,
-    );
+      const expectedBucketName = getBucketName(
+        AWS_CEREMONY_BUCKET_POSTFIX,
+        projectDto.name,
+        ceremonyDto.description,
+      );
 
-    expect(body.bucketName).toBe(expectedBucketName);
-  }, 15000); // S3 bucket creation can be slow in CI
+      expect(body.bucketName).toBe(expectedBucketName);
+    },
+    15000,
+  ); // S3 bucket creation can be slow in CI
 
   it('should create a participant', async () => {
     const response = await fetch(`${TEST_URL}/participants`, {
@@ -278,7 +307,7 @@ describe('Coordinator (e2e)', () => {
       },
       body: JSON.stringify({ uploadId }),
     });
-    expect(mpuResponse.status).toBe(200);
+    expect(mpuResponse.ok).toBe(true);
 
     const chunkUrl = new URL(
       `${TEST_URL}/storage/temporary-store-current-contribution-uploaded-chunk-data`,
@@ -295,7 +324,7 @@ describe('Coordinator (e2e)', () => {
       },
       body: JSON.stringify(chunkPayload),
     });
-    expect(chunkResponse.status).toBe(200);
+    expect(chunkResponse.ok).toBe(true);
 
     const participantRow = await Participant.findOne({
       where: { userId: coordinatorId, ceremonyId },
@@ -309,7 +338,7 @@ describe('Coordinator (e2e)', () => {
     expect(temp?.chunks).toEqual([chunkPayload.chunk]);
   });
 
-  it(
+  awsIt(
     'should upload the circuit artifacts to the bucket',
     async () => {
       // make the download directory if it doesn't exist

--- a/apps/backend/test/coordinator.e2e-spec.ts
+++ b/apps/backend/test/coordinator.e2e-spec.ts
@@ -338,6 +338,25 @@ describe('Coordinator (e2e)', () => {
     expect(temp?.chunks).toEqual([chunkPayload.chunk]);
   });
 
+  it('should reject storage temporary-state endpoints when JWT userId does not match query userId', async () => {
+    const mpuUrl = new URL(
+      `${TEST_URL}/storage/temporary-store-current-contribution-multipart-upload-id`,
+    );
+    mpuUrl.searchParams.set('id', String(ceremonyId));
+    mpuUrl.searchParams.set('userId', String((coordinatorId ?? 0) + 1));
+
+    const response = await fetch(mpuUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwtToken}`,
+      },
+      body: JSON.stringify({ uploadId: 'forbidden-upload-id' }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
   awsIt(
     'should upload the circuit artifacts to the bucket',
     async () => {

--- a/apps/backend/test/coordinator.e2e-spec.ts
+++ b/apps/backend/test/coordinator.e2e-spec.ts
@@ -292,12 +292,16 @@ describe('Coordinator (e2e)', () => {
   });
 
   it('should accept storage temporary-state endpoints matching @brebaje/actions multipart contract', async () => {
+    if (coordinatorId == null) {
+      throw new Error('Expected coordinatorId to be defined');
+    }
+
     const uploadId = 'e2e-test-multipart-upload-id';
     const mpuUrl = new URL(
       `${TEST_URL}/storage/temporary-store-current-contribution-multipart-upload-id`,
     );
     mpuUrl.searchParams.set('id', String(ceremonyId));
-    mpuUrl.searchParams.set('userId', String(coordinatorId));
+    mpuUrl.searchParams.set('userId', String(coordinatorId + 999));
 
     const mpuResponse = await fetch(mpuUrl.toString(), {
       method: 'POST',
@@ -313,7 +317,7 @@ describe('Coordinator (e2e)', () => {
       `${TEST_URL}/storage/temporary-store-current-contribution-uploaded-chunk-data`,
     );
     chunkUrl.searchParams.set('id', String(ceremonyId));
-    chunkUrl.searchParams.set('userId', String(coordinatorId));
+    chunkUrl.searchParams.set('userId', String(coordinatorId + 999));
 
     const chunkPayload = { chunk: { ETag: '"e2e-etag"', PartNumber: 1 } };
     const chunkResponse = await fetch(chunkUrl.toString(), {
@@ -336,6 +340,23 @@ describe('Coordinator (e2e)', () => {
     expect(temp).toBeDefined();
     expect(temp?.uploadId).toBe(uploadId);
     expect(temp?.chunks).toEqual([chunkPayload.chunk]);
+  });
+
+  it('should reject unauthenticated storage temporary-state requests', async () => {
+    const url = new URL(
+      `${TEST_URL}/storage/temporary-store-current-contribution-multipart-upload-id`,
+    );
+    url.searchParams.set('id', String(ceremonyId));
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ uploadId: 'unauthenticated-upload-id' }),
+    });
+
+    expect(response.status).toBe(401);
   });
 
   awsIt(

--- a/apps/backend/test/e2e-env.setup.ts
+++ b/apps/backend/test/e2e-env.setup.ts
@@ -1,0 +1,14 @@
+import { existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Runs before any e2e spec module is loaded. `DB_SQLITE_SYNCHRONIZE` must be set
+ * before `src/utils/constants.ts` is first evaluated (SequelizeModule uses it at import time).
+ */
+process.env.DB_SQLITE_SYNCHRONIZE = 'true';
+
+const e2eDbDir = join(__dirname, '.e2e-db');
+if (!existsSync(e2eDbDir)) {
+  mkdirSync(e2eDbDir, { recursive: true });
+}
+process.env.DB_SQLITE_STORAGE_PATH = join(e2eDbDir, 'data.sqlite3');

--- a/apps/backend/test/jest-e2e.json
+++ b/apps/backend/test/jest-e2e.json
@@ -2,6 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
   "testEnvironment": "node",
+  "setupFiles": ["<rootDir>/e2e-env.setup.ts"],
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.ts$": "ts-jest"

--- a/packages/actions/src/helpers/storage.ts
+++ b/packages/actions/src/helpers/storage.ts
@@ -32,7 +32,7 @@ export const getBucketName = (postfix: string, project: string, description?: st
 export const getChunksAndPreSignedUrlsAPI = async (
   accessToken: string,
   ceremonyId: number,
-  userId: number,
+  _userId: number,
   objectKey: string,
   localFilePath: string,
   uploadId: string,
@@ -159,7 +159,7 @@ export const uploadPartsAPI = async (
  */
 export const completeMultiPartUploadAPI = async (
   ceremonyId: number,
-  userId: number,
+  _userId: number,
   token: string,
   objectKey: string,
   uploadId: string,
@@ -168,7 +168,6 @@ export const completeMultiPartUploadAPI = async (
   const url = new URL(`${process.env.API_URL}/storage/multipart/complete`);
   url.search = new URLSearchParams({
     id: ceremonyId.toString(),
-    userId: userId.toString(),
   }).toString();
   const result = (await fetch(url.toString(), {
     headers: {
@@ -194,7 +193,7 @@ export const completeMultiPartUploadAPI = async (
  */
 export const temporaryStoreCurrentContributionUploadedChunkDataAPI = async (
   ceremonyId: number,
-  userId: number,
+  _userId: number,
   token: string,
   chunk: ETagWithPartNumber,
 ) => {
@@ -203,7 +202,6 @@ export const temporaryStoreCurrentContributionUploadedChunkDataAPI = async (
   );
   url.search = new URLSearchParams({
     id: ceremonyId.toString(),
-    userId: userId.toString(),
   }).toString();
   const result = await fetch(url.toString(), {
     headers: {
@@ -237,13 +235,12 @@ export const generatePreSignedUrlsPartsAPI = async (
   uploadId: string,
   numberOfParts: number,
   ceremonyId: number,
-  userId: number,
+  _userId: number,
   token: string,
 ) => {
   const url = new URL(`${process.env.API_URL}/storage/multipart/urls`);
   url.search = new URLSearchParams({
     id: ceremonyId.toString(),
-    userId: userId.toString(),
   }).toString();
   const result = (await fetch(url.toString(), {
     headers: {
@@ -272,13 +269,12 @@ export const generatePreSignedUrlsPartsAPI = async (
 export const openMultiPartUploadAPI = async (
   objectKey: string,
   ceremonyId: number,
-  userId: number,
+  _userId: number,
   token: string,
 ) => {
   const url = new URL(`${process.env.API_URL}/storage/multipart/start`);
   url.search = new URLSearchParams({
     id: ceremonyId.toString(),
-    userId: userId.toString(),
   }).toString();
   const result = await fetch(url.toString(), {
     headers: {
@@ -319,7 +315,7 @@ export const openMultiPartUploadAPI = async (
  */
 export const temporaryStoreCurrentContributionMultiPartUploadIdAPI = async (
   ceremonyId: number,
-  userId: number,
+  _userId: number,
   uploadId: string,
   token: string,
 ) => {
@@ -328,7 +324,6 @@ export const temporaryStoreCurrentContributionMultiPartUploadIdAPI = async (
   );
   url.search = new URLSearchParams({
     id: ceremonyId.toString(),
-    userId: userId.toString(),
   }).toString();
   const result = await fetch(url.toString(), {
     headers: {

--- a/packages/actions/src/helpers/storage.ts
+++ b/packages/actions/src/helpers/storage.ts
@@ -56,7 +56,7 @@ export const getChunksAndPreSignedUrlsAPI = async (
     uploadId,
     chunks.length,
     ceremonyId,
-    userId,
+    _userId,
     accessToken,
   );
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ ignoredBuiltDependencies:
   - nx
   - sqlite3
   - unrs-resolver
+# Explicitly allow postinstall/build scripts for packages with required native/runtime artifacts.
+# This keeps pnpm's build-script policy locked down while still letting AWS/storage test deps work.
 onlyBuiltDependencies:
   - aws-sdk
   - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,13 @@ ignoredBuiltDependencies:
   - nx
   - sqlite3
   - unrs-resolver
+onlyBuiltDependencies:
+  - aws-sdk
+  - bufferutil
+  - chacha-native
+  - core-js
+  - core-js-pure
+  - esbuild
+  - node-datachannel
+  - utf-8-validate
+  - utp-native


### PR DESCRIPTION
Use this:

## Summary
Secures contribution multipart storage flows by deriving the acting user from JWT auth instead of trusting caller-supplied `userId`, and carries forward the resumable multipart temp-store support from `#102`.

## Changes
- merged the resumable multipart temp-store endpoint work into this branch
- updated multipart and temp-store storage endpoints to use authenticated user identity from JWT
- removed `userId` from the actions client HTTP contract for these requests
- kept coordinator override behavior, but tied it to authenticated identity only
- refreshed controller, service, and e2e coverage for the new auth model

## Validation
- storage controller and service tests pass
- coordinator e2e passes for the authenticated temp-store flow
- AWS-backed S3 e2e cases remain skipped when AWS credentials are not configured

## Notes
- query/body identity tampering can no longer affect authorization for multipart contribution operations