### PR TITLE
feat(ceremonies): enforce auth provider whitelist at enrollment

### DIFF
--- a/apps/backend/src/ceremonies/ceremonies.controller.spec.ts
+++ b/apps/backend/src/ceremonies/ceremonies.controller.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
-import { CeremonyState, CeremonyType } from 'src/types/enums';
+import { CeremonyState, CeremonyType, UserProvider } from 'src/types/enums';
 import { CreateCeremonyDto } from './dto/create-ceremony.dto';
 import { UpdateCeremonyDto } from './dto/update-ceremony.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
@@ -71,7 +71,7 @@ describe('CeremoniesController', () => {
         start_date: 1672531200,
         end_date: 1675209600,
         penalty: 100,
-        authProviders: { github: true, eth: false },
+        authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
       };
 
       const expectedResult = {
@@ -100,7 +100,7 @@ describe('CeremoniesController', () => {
           start_date: 1672531200,
           end_date: 1675209600,
           penalty: 100,
-          authProviders: { github: true, eth: false },
+          authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
         },
       ];
 
@@ -121,7 +121,7 @@ describe('CeremoniesController', () => {
         start_date: 1672531200,
         end_date: 1675209600,
         penalty: 100,
-        authProviders: { github: true, eth: false },
+        authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
       };
 
       jest.spyOn(service, 'findOne').mockResolvedValue(expectedResult as any);
@@ -147,7 +147,7 @@ describe('CeremoniesController', () => {
         start_date: 1672531200,
         end_date: 1675209600,
         penalty: 100,
-        authProviders: { github: true, eth: false },
+        authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
       };
 
       jest.spyOn(service, 'update').mockResolvedValue(expectedResult as any);

--- a/apps/backend/src/ceremonies/ceremonies.service.spec.ts
+++ b/apps/backend/src/ceremonies/ceremonies.service.spec.ts
@@ -1,7 +1,7 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
-import { CeremonyState, CeremonyType } from 'src/types/enums';
+import { CeremonyState, CeremonyType, UserProvider } from 'src/types/enums';
 import { CeremoniesService } from './ceremonies.service';
 import { CreateCeremonyDto } from './dto/create-ceremony.dto';
 import { UpdateCeremonyDto } from './dto/update-ceremony.dto';
@@ -35,7 +35,7 @@ describe('CeremoniesService', () => {
     start_date: 1672531200,
     end_date: 1675209600,
     penalty: 100,
-    authProviders: { github: true, eth: false },
+    authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
     update: jest.fn(),
     destroy: jest.fn(),
   };
@@ -75,7 +75,7 @@ describe('CeremoniesService', () => {
         start_date: 1672531200,
         end_date: 1675209600,
         penalty: 100,
-        authProviders: { github: true, eth: false },
+        authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
       };
 
       mockCeremonyModel.create.mockResolvedValueOnce({
@@ -98,7 +98,7 @@ describe('CeremoniesService', () => {
         start_date: 1672531200,
         end_date: 1675209600,
         penalty: 100,
-        authProviders: { github: true, eth: false },
+        authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
       };
 
       const error = new Error('Ceremony already exists');

--- a/apps/backend/src/ceremonies/ceremony.model.ts
+++ b/apps/backend/src/ceremonies/ceremony.model.ts
@@ -1,6 +1,6 @@
 import { Optional } from 'sequelize';
 import { Column, DataType, Model, Table, BelongsTo, HasMany } from 'sequelize-typescript';
-import { CeremonyType, CeremonyState } from 'src/types/enums';
+import { CeremonyType, CeremonyState, UserProvider } from 'src/types/enums';
 import { Project } from 'src/projects/project.model';
 import { Circuit } from 'src/circuits/circuit.model';
 import { Participant } from 'src/participants/participant.model';
@@ -14,7 +14,7 @@ export interface CeremonyAttributes {
   start_date: number;
   end_date: number;
   penalty: number;
-  authProviders: object;
+  authProviders: UserProvider[];
 }
 
 export type CeremonyPk = 'id';
@@ -80,9 +80,9 @@ export class Ceremony extends Model implements CeremonyAttributes {
   @Column({
     type: DataType.JSON,
     allowNull: false,
-    comment: 'check auth providers classes',
+    comment: 'Non-empty array of UserProvider enum values allowed to enroll',
   })
-  declare authProviders: object;
+  declare authProviders: UserProvider[];
 
   @BelongsTo(() => Project, 'projectId')
   declare project: Project;

--- a/apps/backend/src/ceremonies/dto/create-ceremony.dto.spec.ts
+++ b/apps/backend/src/ceremonies/dto/create-ceremony.dto.spec.ts
@@ -1,0 +1,112 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CeremonyState, CeremonyType, UserProvider } from 'src/types/enums';
+import { CreateCeremonyDto } from './create-ceremony.dto';
+import { UpdateCeremonyDto } from './update-ceremony.dto';
+
+function validCreatePayload(): CreateCeremonyDto {
+  return {
+    projectId: 1,
+    description: 'Test Ceremony',
+    type: CeremonyType.PHASE2,
+    state: CeremonyState.SCHEDULED,
+    start_date: 1672531200,
+    end_date: 1675209600,
+    penalty: 100,
+    authProviders: [UserProvider.GITHUB],
+  };
+}
+
+async function validateCreateDto(payload: object) {
+  const dto = plainToInstance(CreateCeremonyDto, payload);
+  return validate(dto);
+}
+
+async function validateUpdateDto(payload: object) {
+  const dto = plainToInstance(UpdateCeremonyDto, payload);
+  return validate(dto);
+}
+
+describe('CreateCeremonyDto', () => {
+  it('should accept a single valid provider', async () => {
+    const errors = await validateCreateDto(validCreatePayload());
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should accept multiple valid providers', async () => {
+    const errors = await validateCreateDto({
+      ...validCreatePayload(),
+      authProviders: [UserProvider.GITHUB, UserProvider.ETHEREUM],
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject an empty authProviders array', async () => {
+    const errors = await validateCreateDto({
+      ...validCreatePayload(),
+      authProviders: [],
+    });
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+
+  it('should reject an unknown provider identifier', async () => {
+    const errors = await validateCreateDto({
+      ...validCreatePayload(),
+      authProviders: ['UNKNOWN'],
+    });
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+
+  it('should reject mixed known and unknown providers', async () => {
+    const errors = await validateCreateDto({
+      ...validCreatePayload(),
+      authProviders: [UserProvider.GITHUB, 'UNKNOWN'],
+    });
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+
+  it('should reject the legacy boolean-map authProviders shape', async () => {
+    const errors = await validateCreateDto({
+      ...validCreatePayload(),
+      authProviders: { github: true },
+    });
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+
+  it('should reject when authProviders is omitted', async () => {
+    const payload = validCreatePayload();
+    delete (payload as Partial<CreateCeremonyDto>).authProviders;
+    const errors = await validateCreateDto(payload);
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+});
+
+describe('UpdateCeremonyDto authProviders', () => {
+  it('should accept a valid authProviders update', async () => {
+    const errors = await validateUpdateDto({
+      authProviders: [UserProvider.CARDANO],
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject an empty authProviders array on update', async () => {
+    const errors = await validateUpdateDto({
+      authProviders: [],
+    });
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+
+  it('should reject an unknown provider on update', async () => {
+    const errors = await validateUpdateDto({
+      authProviders: ['INVALID'],
+    });
+    expect(errors.some((error) => error.property === 'authProviders')).toBe(true);
+  });
+
+  it('should allow updates that omit authProviders', async () => {
+    const errors = await validateUpdateDto({
+      description: 'Updated description only',
+    });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/ceremonies/dto/create-ceremony.dto.ts
+++ b/apps/backend/src/ceremonies/dto/create-ceremony.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNumber, IsObject, IsString } from 'class-validator';
-import { CeremonyState, CeremonyType } from 'src/types/enums';
+import { ArrayNotEmpty, IsArray, IsEnum, IsNumber, IsString } from 'class-validator';
+import { CeremonyState, CeremonyType, UserProvider } from 'src/types/enums';
 
 export class CreateCeremonyDto {
   @ApiProperty({ example: 1 })
@@ -31,7 +31,13 @@ export class CreateCeremonyDto {
   @IsNumber()
   penalty: number;
 
-  @ApiProperty({ example: { github: true, eth: false } })
-  @IsObject()
-  authProviders: object;
+  @ApiProperty({
+    enum: UserProvider,
+    isArray: true,
+    example: [UserProvider.GITHUB],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsEnum(UserProvider, { each: true })
+  authProviders: UserProvider[];
 }

--- a/apps/backend/src/database/diagram.dbml
+++ b/apps/backend/src/database/diagram.dbml
@@ -84,7 +84,7 @@ Table ceremonies {
   start_date int [not null]
   end_date int [not null]
   penalty int [not null]
-  authProviders json [not null, note: 'check auth providers classes']
+  authProviders json [not null, note: 'Non-empty array of UserProvider enum values (GITHUB, ETHEREUM, CARDANO)']
 }
 
 Table circuits {

--- a/apps/backend/src/database/diagram.sql
+++ b/apps/backend/src/database/diagram.sql
@@ -32,7 +32,7 @@ CREATE TABLE "ceremonies" (
   "start_date" INTEGER NOT NULL,
   "end_date" INTEGER NOT NULL,
   "penalty" INTEGER NOT NULL,
-  "authProviders" JSON NOT NULL,
+  "authProviders" JSON NOT NULL, -- Non-empty array of UserProvider enum values (GITHUB, ETHEREUM, CARDANO)
   FOREIGN KEY ("projectId") REFERENCES "projects" ("id")
 );
 

--- a/apps/backend/src/participants/dto/create-participant.dto.ts
+++ b/apps/backend/src/participants/dto/create-participant.dto.ts
@@ -6,6 +6,8 @@ import { IsNumber } from 'class-validator';
  * @param ceremonyId - The ID of the ceremony the participant is associated with
  * userId is obtained from the authenticated request context
  * Status and steps are set to default values upon creation
+ * Enrollment requires the ceremony to be accepting participants and the user's auth
+ * provider to be included in the ceremony's authProviders whitelist (coordinators exempt)
  */
 export class CreateParticipantDto {
   @ApiProperty({

--- a/apps/backend/src/participants/participants.controller.ts
+++ b/apps/backend/src/participants/participants.controller.ts
@@ -38,7 +38,16 @@ export class ParticipantsController {
     description: 'The participant has been successfully created.',
     type: Participant,
   })
-  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad Request — ceremony is not accepting enrollments.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — auth provider is not permitted for this ceremony.',
+  })
+  @ApiResponse({ status: 404, description: 'Ceremony not found.' })
+  @ApiResponse({ status: 409, description: 'Conflict — participant already exists.' })
   create(@Request() req: AuthenticatedRequest, @Body() createParticipantDto: CreateParticipantDto) {
     return this.participantsService.create(createParticipantDto, req.user!.id!);
   }

--- a/apps/backend/src/participants/participants.module.ts
+++ b/apps/backend/src/participants/participants.module.ts
@@ -8,6 +8,7 @@ import { CircuitsModule } from 'src/circuits/circuits.module';
 import { ContributionsModule } from 'src/contributions/contributions.module';
 import { AuthModule } from 'src/auth/auth.module';
 import { CeremoniesModule } from 'src/ceremonies/ceremonies.module';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { CeremoniesModule } from 'src/ceremonies/ceremonies.module';
     forwardRef(() => CircuitsModule),
     forwardRef(() => ContributionsModule),
     forwardRef(() => CeremoniesModule),
+    UsersModule,
     AuthModule,
   ],
   controllers: [ParticipantsController],

--- a/apps/backend/src/participants/participants.service.spec.ts
+++ b/apps/backend/src/participants/participants.service.spec.ts
@@ -8,25 +8,70 @@ import {
   ParticipantContributionStep,
   CircuitTimeoutType,
   VerificationMachineType,
+  CeremonyState,
+  UserProvider,
 } from 'src/types/enums';
 import { Circuit } from 'src/circuits/circuit.model';
 import { ContributionsService } from 'src/contributions/contributions.service';
+import { CeremoniesService } from 'src/ceremonies/ceremonies.service';
+import { UsersService } from 'src/users/users.service';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { CreateParticipantDto } from './dto/create-participant.dto';
+import { Ceremony } from 'src/ceremonies/ceremony.model';
+import { User } from 'src/users/user.model';
 
 describe('ParticipantsService', () => {
   let service: ParticipantsService;
+  let mockParticipantModel: { create: jest.Mock };
   let mockCircuitsService: Partial<CircuitsService>;
   let mockContributionsService: Partial<ContributionsService>;
+  let mockCeremoniesService: Partial<CeremoniesService>;
+  let mockUsersService: Partial<UsersService>;
+
+  const ceremonyId = 1;
+  const userId = 10;
+
+  const createDto: CreateParticipantDto = { ceremonyId };
+
+  const mockCeremony = {
+    id: ceremonyId,
+    state: CeremonyState.OPENED,
+    authProviders: [UserProvider.GITHUB],
+  } as Ceremony;
+
+  const mockUser = {
+    id: userId,
+    provider: UserProvider.GITHUB,
+  } as User;
 
   beforeEach(async () => {
+    mockParticipantModel = {
+      create: jest.fn().mockResolvedValue({
+        id: 1,
+        userId,
+        ceremonyId,
+        status: ParticipantStatus.CREATED,
+        contributionStep: ParticipantContributionStep.DOWNLOADING,
+      }),
+    };
     mockCircuitsService = {};
     mockContributionsService = {};
+    mockCeremoniesService = {
+      findOne: jest.fn().mockResolvedValue(mockCeremony),
+      findCoordinatorOfCeremony: jest.fn().mockResolvedValue(null),
+    };
+    mockUsersService = {
+      findById: jest.fn().mockResolvedValue(mockUser),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ParticipantsService,
-        { provide: getModelToken(Participant), useValue: {} },
+        { provide: getModelToken(Participant), useValue: mockParticipantModel },
         { provide: CircuitsService, useValue: mockCircuitsService },
         { provide: ContributionsService, useValue: mockContributionsService },
+        { provide: CeremoniesService, useValue: mockCeremoniesService },
+        { provide: UsersService, useValue: mockUsersService },
       ],
     }).compile();
 
@@ -35,6 +80,143 @@ describe('ParticipantsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should allow a whitelisted provider to enroll in an OPENED ceremony', async () => {
+      const result = await service.create(createDto, userId);
+
+      expect(mockCeremoniesService.findOne).toHaveBeenCalledWith(ceremonyId);
+      expect(mockUsersService.findById).toHaveBeenCalledWith(userId);
+      expect(mockParticipantModel.create).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        userId,
+        ceremonyId,
+        status: ParticipantStatus.CREATED,
+      });
+    });
+
+    it('should reject a non-whitelisted provider with ForbiddenException', async () => {
+      (mockUsersService.findById as jest.Mock).mockResolvedValueOnce({
+        ...mockUser,
+        provider: UserProvider.ETHEREUM,
+      });
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(ForbiddenException);
+      expect(mockParticipantModel.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject enrollment when authProviders is a legacy boolean map', async () => {
+      (mockCeremoniesService.findOne as jest.Mock).mockResolvedValueOnce({
+        ...mockCeremony,
+        authProviders: { github: true },
+      });
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(ForbiddenException);
+      expect(mockParticipantModel.create).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      CeremonyState.SCHEDULED,
+      CeremonyState.PAUSED,
+      CeremonyState.CLOSED,
+      CeremonyState.CANCELED,
+      CeremonyState.FINALIZED,
+    ])('should reject non-coordinator enrollment when ceremony is %s', async (state) => {
+      (mockCeremoniesService.findOne as jest.Mock).mockResolvedValueOnce({
+        ...mockCeremony,
+        state,
+      });
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(BadRequestException);
+      expect(mockParticipantModel.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject enrollment when ceremony is not found', async () => {
+      (mockCeremoniesService.findOne as jest.Mock).mockRejectedValueOnce(
+        new NotFoundException('Ceremony not found'),
+      );
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(NotFoundException);
+      expect(mockParticipantModel.create).not.toHaveBeenCalled();
+    });
+
+    it('should allow coordinator to bypass provider whitelist', async () => {
+      (mockCeremoniesService.findCoordinatorOfCeremony as jest.Mock).mockResolvedValueOnce({
+        id: ceremonyId,
+      });
+      (mockCeremoniesService.findOne as jest.Mock).mockResolvedValueOnce({
+        ...mockCeremony,
+        authProviders: [UserProvider.ETHEREUM],
+      });
+      (mockUsersService.findById as jest.Mock).mockResolvedValueOnce({
+        ...mockUser,
+        provider: UserProvider.GITHUB,
+      });
+
+      await service.create(createDto, userId);
+
+      expect(mockUsersService.findById).not.toHaveBeenCalled();
+      expect(mockParticipantModel.create).toHaveBeenCalled();
+    });
+
+    it('should allow coordinator to enroll when ceremony is CLOSED', async () => {
+      (mockCeremoniesService.findCoordinatorOfCeremony as jest.Mock).mockResolvedValueOnce({
+        id: ceremonyId,
+      });
+      (mockCeremoniesService.findOne as jest.Mock).mockResolvedValueOnce({
+        ...mockCeremony,
+        state: CeremonyState.CLOSED,
+        authProviders: [UserProvider.ETHEREUM],
+      });
+
+      await service.create(createDto, userId);
+
+      expect(mockParticipantModel.create).toHaveBeenCalled();
+    });
+
+    it.each([CeremonyState.CANCELED, CeremonyState.FINALIZED])(
+      'should reject coordinator enrollment when ceremony is %s',
+      async (state) => {
+        (mockCeremoniesService.findCoordinatorOfCeremony as jest.Mock).mockResolvedValueOnce({
+          id: ceremonyId,
+        });
+        (mockCeremoniesService.findOne as jest.Mock).mockResolvedValueOnce({
+          ...mockCeremony,
+          state,
+        });
+
+        await expect(service.create(createDto, userId)).rejects.toThrow(BadRequestException);
+        expect(mockParticipantModel.create).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should reject a coordinator of a different ceremony who is not whitelisted', async () => {
+      (mockCeremoniesService.findCoordinatorOfCeremony as jest.Mock).mockResolvedValueOnce(null);
+      (mockUsersService.findById as jest.Mock).mockResolvedValueOnce({
+        ...mockUser,
+        provider: UserProvider.ETHEREUM,
+      });
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(ForbiddenException);
+      expect(mockParticipantModel.create).not.toHaveBeenCalled();
+    });
+
+    it('should read provider from the user record, not session credentials', async () => {
+      (mockUsersService.findById as jest.Mock).mockResolvedValueOnce({
+        ...mockUser,
+        provider: UserProvider.ETHEREUM,
+      });
+      (mockCeremoniesService.findOne as jest.Mock).mockResolvedValueOnce({
+        ...mockCeremony,
+        authProviders: [UserProvider.ETHEREUM, UserProvider.GITHUB],
+      });
+
+      await service.create(createDto, userId);
+
+      expect(mockUsersService.findById).toHaveBeenCalledWith(userId);
+      expect(mockParticipantModel.create).toHaveBeenCalled();
+    });
   });
 
   describe('addParticipantToCircuitsQueues', () => {

--- a/apps/backend/src/participants/participants.service.ts
+++ b/apps/backend/src/participants/participants.service.ts
@@ -10,16 +10,44 @@ import {
   ForbiddenException,
   Inject,
   forwardRef,
+  HttpException,
 } from '@nestjs/common';
 import { CreateParticipantDto } from './dto/create-participant.dto';
 import { Participant } from './participant.model';
-import { ParticipantStatus, ParticipantContributionStep, CeremonyState } from 'src/types/enums';
+import {
+  ParticipantStatus,
+  ParticipantContributionStep,
+  CeremonyState,
+  UserProvider,
+} from 'src/types/enums';
 import { WhereOptions } from 'sequelize';
 import { InjectModel } from '@nestjs/sequelize';
 import { formatZkeyIndex } from '@brebaje/actions';
 import { CircuitsService } from 'src/circuits/circuits.service';
 import { ContributionsService } from 'src/contributions/contributions.service';
+import { CeremoniesService } from 'src/ceremonies/ceremonies.service';
+import { UsersService } from 'src/users/users.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
+
+const VALID_USER_PROVIDERS = new Set(Object.values(UserProvider));
+
+/**
+ * Returns the ceremony auth provider whitelist when it is a non-empty array of known providers.
+ * Returns null for legacy or malformed values so enrollment fails closed.
+ */
+function parseAuthProvidersWhitelist(authProviders: unknown): UserProvider[] | null {
+  if (!Array.isArray(authProviders) || authProviders.length === 0) {
+    return null;
+  }
+
+  for (const provider of authProviders) {
+    if (!VALID_USER_PROVIDERS.has(provider as UserProvider)) {
+      return null;
+    }
+  }
+
+  return authProviders as UserProvider[];
+}
 
 @Injectable()
 export class ParticipantsService {
@@ -30,10 +58,19 @@ export class ParticipantsService {
     private readonly circuitsService: CircuitsService,
     @Inject(forwardRef(() => ContributionsService))
     private readonly contributionsService: ContributionsService,
+    @Inject(forwardRef(() => CeremoniesService))
+    private readonly ceremoniesService: CeremoniesService,
+    private readonly usersService: UsersService,
   ) {}
 
   /**
    * Creates a new participant.
+   *
+   * Enrollment is gated by ceremony state and the ceremony's auth provider whitelist.
+   * Non-coordinators may enroll only when the ceremony is OPENED and their provider
+   * is whitelisted. Coordinators bypass the provider whitelist and may also enroll when
+   * the ceremony is CLOSED (required for finalization). The enrolling user's provider
+   * is read from the database, not from the JWT.
    *
    * @param createParticipantDto - The DTO containing participant creation data
    * @param userId - The ID of the authenticated user creating the participant
@@ -41,6 +78,33 @@ export class ParticipantsService {
    */
   async create(createParticipantDto: CreateParticipantDto, userId: number) {
     try {
+      const ceremony = await this.ceremoniesService.findOne(createParticipantDto.ceremonyId);
+
+      const coordinatorCeremony = await this.ceremoniesService.findCoordinatorOfCeremony(
+        userId,
+        createParticipantDto.ceremonyId,
+      );
+      const isCoordinator = !!coordinatorCeremony;
+
+      const allowedStates = isCoordinator
+        ? [CeremonyState.OPENED, CeremonyState.CLOSED]
+        : [CeremonyState.OPENED];
+
+      if (!allowedStates.includes(ceremony.state)) {
+        throw new BadRequestException('Ceremony is not accepting enrollments');
+      }
+
+      if (!isCoordinator) {
+        const user = await this.usersService.findById(userId);
+        const whitelist = parseAuthProvidersWhitelist(ceremony.authProviders);
+
+        if (!whitelist || !whitelist.includes(user.provider)) {
+          throw new ForbiddenException(
+            'This ceremony does not accept participants authenticated with your auth provider',
+          );
+        }
+      }
+
       const participant = await this.participantModel.create({
         ...createParticipantDto,
         userId,
@@ -50,6 +114,9 @@ export class ParticipantsService {
 
       return participant;
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
       this.handleErrors(error as Error);
     }
   }

--- a/apps/backend/test/constants.ts
+++ b/apps/backend/test/constants.ts
@@ -32,7 +32,7 @@ export const ceremonyDto: CreateCeremonyDto = {
   start_date: startDate,
   end_date: endDate,
   penalty: 1,
-  authProviders: { github: true },
+  authProviders: [UserProvider.GITHUB],
 };
 
 export const circuits: CreateCircuitDto[] = [

--- a/apps/backend/test/coordinator.e2e-spec.ts
+++ b/apps/backend/test/coordinator.e2e-spec.ts
@@ -26,7 +26,12 @@ import { zKey } from 'snarkjs';
 import { Circuit } from 'src/circuits/circuit.model';
 import { JwtService } from '@nestjs/jwt';
 import { Participant } from 'src/participants/participant.model';
-import { ParticipantContributionStep, ParticipantStatus } from 'src/types/enums';
+import {
+  ParticipantContributionStep,
+  ParticipantStatus,
+  CeremonyState,
+  UserProvider,
+} from 'src/types/enums';
 
 const DOWNLOAD_DIRECTORY = './.downloads';
 const TEST_URL = `http://localhost:${PORT}`;
@@ -240,6 +245,80 @@ describe('Coordinator (e2e)', () => {
     },
     15000,
   ); // S3 bucket creation can be slow in CI
+
+  it('should open the ceremony for enrollment', async () => {
+    const response = await fetch(`${TEST_URL}/ceremonies/${ceremonyId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwtToken}`,
+      },
+      body: JSON.stringify({ state: CeremonyState.OPENED }),
+    });
+
+    expect(response.ok).toBe(true);
+    const body = (await response.json()) as Ceremony;
+    expect(body.state).toBe(CeremonyState.OPENED);
+  });
+
+  it('should reject enrollment when the user auth provider is not whitelisted', async () => {
+    const ethereumUser = await User.create({
+      displayName: 'ethereum-participant',
+      provider: UserProvider.ETHEREUM,
+      creationTime: Date.now(),
+    });
+
+    const authResponse = await fetch(`${TEST_URL}/auth/test/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: ethereumUser.id }),
+    });
+    const authBody = (await authResponse.json()) as { jwt: string };
+
+    const response = await fetch(`${TEST_URL}/participants`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authBody.jwt}`,
+      },
+      body: JSON.stringify({ ceremonyId }),
+    });
+
+    expect(response.status).toBe(403);
+
+    await User.destroy({ where: { id: ethereumUser.id } });
+  });
+
+  it('should allow enrollment when the user auth provider is whitelisted', async () => {
+    const githubParticipant = await User.create({
+      displayName: 'github-participant',
+      provider: UserProvider.GITHUB,
+      creationTime: Date.now(),
+    });
+
+    const authResponse = await fetch(`${TEST_URL}/auth/test/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: githubParticipant.id }),
+    });
+    const authBody = (await authResponse.json()) as { jwt: string };
+
+    const response = await fetch(`${TEST_URL}/participants`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authBody.jwt}`,
+      },
+      body: JSON.stringify({ ceremonyId }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as Participant;
+    expect(body.userId).toBe(githubParticipant.id);
+
+    await Participant.destroy({ where: { id: body.id } });
+    await User.destroy({ where: { id: githubParticipant.id } });
+  });
 
   it('should create a participant', async () => {
     const response = await fetch(`${TEST_URL}/participants`, {

--- a/apps/cli/src/ceremonies/create.spec.ts
+++ b/apps/cli/src/ceremonies/create.spec.ts
@@ -2,7 +2,7 @@ import { create } from "./create";
 import * as utils from "./utils";
 import { ScriptLogger } from "../utils/logger";
 import { authenticatedFetch } from "../auth/http";
-import { CeremonyCreate, CeremonyType, CeremonyState } from "./declarations";
+import { CeremonyCreate, CeremonyType, CeremonyState, UserProvider } from "./declarations";
 
 jest.mock("../utils/logger");
 jest.mock("./utils");
@@ -29,7 +29,7 @@ describe("create", () => {
       start_date: 1700000000,
       end_date: 1700003600,
       penalty: 0,
-      authProviders: { github: true },
+      authProviders: [UserProvider.GITHUB],
     };
     (utils.readTemplate as jest.Mock).mockReturnValue(template);
     (utils.validateCreateTemplate as jest.Mock).mockReturnValue(undefined);
@@ -69,7 +69,7 @@ describe("create", () => {
       start_date: 1700000000,
       end_date: 1700003600,
       penalty: 0,
-      authProviders: { github: true },
+      authProviders: [UserProvider.GITHUB],
     };
     (utils.readTemplate as jest.Mock).mockReturnValue(template);
     (utils.validateCreateTemplate as jest.Mock).mockReturnValue(undefined);

--- a/apps/cli/src/ceremonies/declarations.ts
+++ b/apps/cli/src/ceremonies/declarations.ts
@@ -15,6 +15,12 @@ export enum CeremonyState {
   FINALIZED = "FINALIZED",
 }
 
+export enum UserProvider {
+  GITHUB = "GITHUB",
+  ETHEREUM = "ETHEREUM",
+  CARDANO = "CARDANO",
+}
+
 // Ceremony creation template (matches CreateCeremonyDto)
 export interface CeremonyCreate {
   projectId: number;
@@ -24,7 +30,7 @@ export interface CeremonyCreate {
   start_date: number;
   end_date: number;
   penalty: number;
-  authProviders: Record<string, boolean>;
+  authProviders: UserProvider[];
 }
 
 // Ceremony update template (matches UpdateCeremonyDto, all fields optional except id)
@@ -35,7 +41,7 @@ export interface CeremonyUpdate {
   start_date?: number;
   end_date?: number;
   penalty?: number;
-  authProviders?: Record<string, boolean>;
+  authProviders?: UserProvider[];
 }
 
 // Ceremony API response (matches backend model)
@@ -48,5 +54,5 @@ export interface Ceremony {
   start_date: number;
   end_date: number;
   penalty: number;
-  authProviders: Record<string, boolean>;
+  authProviders: UserProvider[];
 }

--- a/apps/cli/src/ceremonies/utils.spec.ts
+++ b/apps/cli/src/ceremonies/utils.spec.ts
@@ -1,0 +1,69 @@
+import { CeremonyState, CeremonyType, UserProvider } from "./declarations";
+import { validateCreateTemplate, validateUpdateTemplate } from "./utils";
+
+describe("ceremony template authProviders validation", () => {
+  const validCreateTemplate = {
+    projectId: 1,
+    type: CeremonyType.PHASE2,
+    state: CeremonyState.SCHEDULED,
+    start_date: 1700000000,
+    end_date: 1700003600,
+    penalty: 0,
+    authProviders: [UserProvider.GITHUB],
+  };
+
+  it("should accept a non-empty array of valid providers on create", () => {
+    expect(() => validateCreateTemplate(validCreateTemplate)).not.toThrow();
+  });
+
+  it("should reject an empty authProviders array on create", () => {
+    expect(() =>
+      validateCreateTemplate({
+        ...validCreateTemplate,
+        authProviders: [],
+      }),
+    ).toThrow(/authProviders must be a non-empty array/);
+  });
+
+  it("should reject an unknown provider on create", () => {
+    expect(() =>
+      validateCreateTemplate({
+        ...validCreateTemplate,
+        authProviders: ["UNKNOWN"],
+      }),
+    ).toThrow(/authProviders must be a non-empty array/);
+  });
+
+  it("should reject the legacy boolean-map authProviders shape on create", () => {
+    expect(() =>
+      validateCreateTemplate({
+        ...validCreateTemplate,
+        authProviders: { github: true },
+      }),
+    ).toThrow(/authProviders must be a non-empty array/);
+  });
+
+  it("should accept a valid authProviders update", () => {
+    expect(() =>
+      validateUpdateTemplate({
+        authProviders: [UserProvider.ETHEREUM],
+      }),
+    ).not.toThrow();
+  });
+
+  it("should reject an empty authProviders array on update", () => {
+    expect(() =>
+      validateUpdateTemplate({
+        authProviders: [],
+      }),
+    ).toThrow(/authProviders must be a non-empty array/);
+  });
+
+  it("should allow updates that omit authProviders", () => {
+    expect(() =>
+      validateUpdateTemplate({
+        description: "Updated only",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/cli/src/ceremonies/utils.ts
+++ b/apps/cli/src/ceremonies/utils.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { CeremonyType, CeremonyState } from "./declarations";
+import { CeremonyType, CeremonyState, UserProvider } from "./declarations";
 
 /**
  * Reads and parses a JSON template file.
@@ -34,6 +34,29 @@ export function isValidCeremonyType(type: any): type is CeremonyType {
  */
 export function isValidCeremonyState(state: any): state is CeremonyState {
   return Object.values(CeremonyState).includes(state);
+}
+
+/**
+ * Checks if a value is a valid UserProvider.
+ */
+export function isValidUserProvider(provider: unknown): provider is UserProvider {
+  return Object.values(UserProvider).includes(provider as UserProvider);
+}
+
+function validateAuthProviders(authProviders: unknown): void {
+  if (!Array.isArray(authProviders) || authProviders.length === 0) {
+    throw new Error(
+      `authProviders must be a non-empty array of UserProvider values: ${Object.values(UserProvider).join(", ")}`,
+    );
+  }
+
+  for (const provider of authProviders) {
+    if (!isValidUserProvider(provider)) {
+      throw new Error(
+        `authProviders must be a non-empty array of UserProvider values: ${Object.values(UserProvider).join(", ")}`,
+      );
+    }
+  }
 }
 
 /**
@@ -77,9 +100,7 @@ export function validateCreateTemplate(template: any): void {
   if (typeof template.penalty !== "number" || template.penalty < 0) {
     throw new Error("penalty must be a non-negative number");
   }
-  if (typeof template.authProviders !== "object" || template.authProviders === null) {
-    throw new Error("authProviders must be an object");
-  }
+  validateAuthProviders(template.authProviders);
 }
 
 /**
@@ -116,10 +137,7 @@ export function validateUpdateTemplate(template: any): void {
   ) {
     throw new Error("penalty must be a non-negative number");
   }
-  if (
-    template.authProviders !== undefined &&
-    (typeof template.authProviders !== "object" || template.authProviders === null)
-  ) {
-    throw new Error("authProviders must be an object");
+  if (template.authProviders !== undefined) {
+    validateAuthProviders(template.authProviders);
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,7 +217,7 @@ User ──(coordinator of)──▶ Project ──▶ Ceremony ──▶ Circui
 | ------------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | User         | `users/user.model.ts`                 | `id`, `displayName` (indexed), `provider` (enum), `walletAddress` (Cardano/Ethereum), `avatarUrl`, timestamps                                                                             |
 | Project      | `projects/project.model.ts`           | `id`, `name`, `contact`, `coordinatorId` (FK → User)                                                                                                                                      |
-| Ceremony     | `ceremonies/ceremony.model.ts`        | `id`, `projectId`, `state` (enum), `type` (enum), `start_date`, `end_date`, `penalty`, `authProviders` (JSON)                                                                             |
+| Ceremony     | `ceremonies/ceremony.model.ts`        | `id`, `projectId`, `state` (enum), `type` (enum), `start_date`, `end_date`, `penalty`, `authProviders` (JSON array of `UserProvider` values)                                              |
 | Circuit      | `circuits/circuit.model.ts`           | `id`, `ceremonyId`, `name`, `sequencePosition`, `timeoutMechanismType` (enum), `currentContributor`, `contributors` (JSON), `verification` (JSON), `artifacts` (JSON), `pot`              |
 | Participant  | `participants/participant.model.ts`   | `id`, `userId`, `ceremonyId` (unique together — one participant per ceremony per user), `status` (enum), `contributionStep` (enum), `tempContributionData` (JSON), `timeout` (JSON array) |
 | Contribution | `contributions/contribution.model.ts` | `id`, `circuitId`, `participantId`, `zkeyIndex`, `valid`, timing fields, `files` (JSON), `verificationSoftware` (JSON), `beacon` (JSON)                                                   |
@@ -274,10 +274,15 @@ authenticating with GitHub and then with Ethereum results in two separate accoun
 identities into a single account. Until then, the one-provider-per-user model is
 intentional but temporary.
 
-Per-ceremony **provider whitelist** (`ceremony.authProviders` JSON column): stores the list
-of allowed auth providers for a ceremony. Enforcement at enrollment is **not yet
-implemented** — `participants.service.ts` does not currently check the participant's
-provider against this list, so any authenticated user can enroll in any ceremony.
+Per-ceremony **provider whitelist** (`ceremony.authProviders` JSON column): a non-empty
+array of `UserProvider` enum values (`GITHUB`, `ETHEREUM`, `CARDANO`) validated at ceremony
+create and update. At enrollment, `ParticipantsService.create()` loads the ceremony and
+enforces two gates: the ceremony must be `OPENED` (or `CLOSED` for the coordinator), and
+the enrolling user's provider must appear in the whitelist. The provider is read from the
+user record, not the JWT. Enrollment fails closed when the whitelist is missing, empty, or
+in a legacy format. The ceremony coordinator bypasses the provider whitelist so they can
+obtain the participant record required for finalization. Already-enrolled participants are
+grandfathered if the whitelist is narrowed later — the gate applies only at enrollment.
 
 **Nonce management** (in `auth.service.ts`):
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -657,7 +657,7 @@ Capabilities:
 - [x] Ceremony setup definition under a project.
 - [x] Ceremony and circuit validation.
 - [x] Participant enrollment.
-- [ ] ⚠️ Auth provider whitelist enforcement at enrollment (`authProviders` field exists on the ceremony but `participants.service.ts` does not check the participant's provider against it).
+- [x] Auth provider whitelist enforcement at enrollment (`authProviders` is a non-empty `UserProvider[]` validated at ceremony create/update; enrollment checks provider and ceremony state, with coordinator bypass).
 - [x] Circuit queues.
 - [x] Fixed and lobby timeout policy.
 - [ ] Dynamic timeout policy (average contribution time tracking not yet implemented — `averageContributionComputationTime` is never updated from real contribution timings).

--- a/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/design.md
+++ b/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/design.md
@@ -1,0 +1,85 @@
+## Context
+
+See proposal.md — Why. The design-relevant constraints:
+
+- `ParticipantsService.create()` spreads the DTO straight into `participantModel.create()` and never loads the ceremony, so there is no existing hook to hang either gate on.
+- `ParticipantsModule` already imports `CeremoniesModule` through `forwardRef`, and `CeremoniesModule` exports `CeremoniesService`. The ceremony lookup needs no new module wiring; only `UsersModule` has to be added.
+- `authProviders` is a `DataType.JSON` column typed as bare `object`, validated with `@IsObject()` alone. The de-facto format is `{ github: true, eth: false }`, whose keys match no `UserProvider` value (`GITHUB`, `ETHEREUM`, `CARDANO`).
+- There is no migration framework. Schema changes are applied by Sequelize `synchronize`, gated on `DB_SQLITE_SYNCHRONIZE`.
+- `JwtAuthGuard` assigns `request.user = payload.user`, embedding the whole `User` record in the token. The controller passes only `req.user!.id!` to the service today.
+- Coordinator finalization depends on a participant record: `storage.service.ts` grants upload access when `isCoordinator` or when the participant's status is `ParticipantStatus.FINALIZING`. That record can only originate from `POST /participants`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `authProviders` a typed, validated contract so the whitelist is enforceable at all.
+- Close the enrollment hole with a single ceremony lookup that covers both the provider and state gates.
+- Keep the coordinator's finalization path working.
+
+**Non-Goals:**
+
+- Normalizing `authProviders` out of a JSON column into a relational shape (join table, or one boolean column per provider). JSON with enum-array validation is sufficient for a small closed set and avoids schema churn.
+- Linking multiple provider identities to one account. `ARCHITECTURE.md` records one-provider-per-user as intentional-but-temporary; provider binding is a separate future change.
+- Re-checking the whitelist on any operation after enrollment. Enrollment is the only gate, and already-enrolled participants are grandfathered if the whitelist is later narrowed.
+- Sharing the `UserProvider` enum between backend and CLI through a package. See Decisions.
+
+## Decisions
+
+### Enum array over keyed boolean map
+
+`authProviders` becomes `UserProvider[]` (`["GITHUB", "ETHEREUM"]`).
+
+The alternative — keeping `{ github: true, eth: false }` and adding a key-to-enum mapping — avoids touching CLI templates and fixtures, but it carries two defects into the enforcement path. First, it needs a hand-maintained mapping table (`eth` → `ETHEREUM`) that will drift the moment a provider is added. Second, `false` and absent are indistinguishable in intent, so "not permitted" and "not configured" collapse into the same value, which is exactly the ambiguity a security gate should not have to interpret.
+
+The enum array removes both. It validates declaratively with `@IsArray()`, `@ArrayNotEmpty()`, and `@IsEnum(UserProvider, { each: true })`, and membership is a plain `includes()` against the value already stored on the user.
+
+The column type is unchanged (`DataType.JSON`), so the cost is confined to producers of the value, not to the schema.
+
+### Validate the whitelist where the coordinator sets it
+
+Enrollment fails closed, so an empty or unparseable whitelist yields a ceremony nobody can join. Rejecting only at enrollment would surface that as participants being turned away — far from the mistake, and invisible to the coordinator until someone complains. Validating at ceremony write time puts the error in front of the person who can fix it.
+
+`UpdateCeremonyDto extends PartialType(CreateCeremonyDto)`, so the create-side decorators apply to `PATCH /ceremonies/:id` whenever the field is present, and are skipped when it is absent. Non-empty-on-create and non-empty-on-update therefore come from one set of decorators with no additional code.
+
+Enrollment still fails closed independently, because ceremony rows written before this change are not revalidated.
+
+### Enforce in the service, not in a guard
+
+A dedicated guard would match the `guards/` convention used for the coordinator checks, and it has access to everything it needs (`req.user`, `req.body.ceremonyId`).
+
+The service is the better home here for two reasons. The project's architecture rules place domain invariants in the service layer, and "who may join a ceremony" is a ceremony invariant rather than a transport concern. More practically, the state gate needs the ceremony row anyway; putting the provider check in a guard would mean loading the same ceremony twice per request, in two places that must agree on the fail-closed semantics.
+
+The existing coordinator guards stay as they are — this is not a rewrite of that pattern, just a decision about where a new check belongs.
+
+### Read the provider from the database, not the JWT
+
+The token is server-signed, so the embedded `provider` cannot be forged. It can, however, be stale: it reflects the user record as of sign-in, and `JWT_EXPIRES_IN` defaults to `1d`. Today `provider` never changes after account creation, so the two sources agree — but the planned provider-binding feature makes the JWT copy wrong for exactly the field this gate depends on, and the failure mode would be a silently bypassed whitelist.
+
+One indexed primary-key read on a rare write path is a cheap way to never have that bug. Cost: `ParticipantsModule` imports `UsersModule`.
+
+The controller keeps passing `userId`; the service resolves the user itself, so the trust boundary is visible in the layer that enforces it rather than spread across controller and service.
+
+### Coordinator bypasses the state gate as well as the provider gate
+
+The exemption was decided for the provider whitelist, but restricting the coordinator to `OPENED` would reintroduce the same lockout through the other gate. Finalization runs after the ceremony stops accepting contributions, so a coordinator who did not happen to enroll while the ceremony was open cannot create the participant record that `storage.service.ts` requires for finalization uploads, and the ceremony becomes unfinalizable.
+
+Coordinators may therefore enroll while the ceremony is `OPENED` or `CLOSED`. `CANCELED` and `FINALIZED` remain closed to everyone, since enrollment there has no purpose. Everyone else is restricted to `OPENED`.
+
+Ownership is determined with the existing `CeremoniesService.findCoordinatorOfCeremony` / `isCoordinator` path, which already joins through `Project.coordinatorId`, so no new ownership logic is introduced.
+
+An alternative was to validate at ceremony-create time that the coordinator's own provider is in the whitelist. It was rejected because it couples ceremony creation to a user lookup, and it still leaves the state half of the problem unsolved.
+
+### Duplicate the `UserProvider` enum in the CLI
+
+The CLI already mirrors `CeremonyType` and `CeremonyState` locally in `ceremonies/declarations.ts` rather than importing them. Mirroring `UserProvider` the same way keeps the change consistent with the surrounding code.
+
+Hoisting the shared enums into `@brebaje/actions` would be the DRY move, but the project's stated principle is WET-first and extract on evidence. One more mirrored enum is the evidence accumulating, not yet the trigger; it is worth doing as its own change covering all three enums rather than smuggling a package-boundary change into a security fix.
+
+## Risks / Trade-offs
+
+- **Breaking format change: any ceremony template or fixture still using the boolean map fails validation.** → The blast radius is fully enumerated in proposal.md — Impact, and every occurrence lives in this repo (CLI validators and declarations, backend and CLI fixtures, e2e constants). The fail-closed enrollment gate means a missed producer surfaces as a rejected request, not as an unguarded enrollment.
+- **Ceremony rows already persisted with the boolean map become unjoinable.** → Intended, and safe by construction: fail-closed denies rather than admits. There is no production deployment, and development databases are recreated. No backfill is written; if one is ever needed it is a standalone script, not part of this change.
+- **`authProviders` remains mutable at any ceremony state, so a coordinator can narrow it mid-ceremony.** → Accepted for now. Already-enrolled participants are unaffected because the gate is only at enrollment, so narrowing cannot invalidate work in progress; it only stops new joins. Constraining whitelist mutation by ceremony state is a separate change.
+- **The coordinator exemption widens what a coordinator can do relative to their own whitelist.** → Bounded to the coordinator of that specific ceremony, resolved through the existing project-ownership join. It grants a participant record, not any contribution privilege: the contribution and upload preconditions in `contributions` and `storage` are unchanged.
+- **One extra ceremony read and one extra user read per enrollment.** → Both are primary-key lookups on a once-per-user-per-ceremony operation, well inside the API latency target.

--- a/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/proposal.md
+++ b/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Every ceremony carries an `authProviders` whitelist, but `ParticipantsService.create()` never loads the ceremony — so any authenticated user can enroll in any ceremony regardless of which auth provider the coordinator allowed, and regardless of whether the ceremony is even open. `POST /participants` is the only path that creates a participant row, so this single unguarded call is the whole gap. It is tracked as a security gap in [docs/PRD.md](../../../docs/PRD.md) and [docs/ARCHITECTURE.md](../../../docs/ARCHITECTURE.md).
+
+The check itself is small; the reason it has not been written is that `authProviders` has no defined shape. It is a bare `object` in the model, validated only with `@IsObject()`, and used as an ad-hoc lowercase boolean map (`{ github: true, eth: false }`) whose keys do not correspond to any `UserProvider` enum value. A whitelist cannot be enforced until it is a real contract.
+
+## What Changes
+
+- **BREAKING**: `authProviders` becomes an array of `UserProvider` enum values (`["GITHUB", "ETHEREUM"]`) instead of an untyped boolean map (`{ github: true, eth: false }`). The DB column stays JSON, so no DDL migration is required, but every producer of the field changes: the ceremony DTOs, the CLI ceremony templates and their validators, and all test fixtures.
+- `CreateCeremonyDto.authProviders` gains real validation: a non-empty array of known `UserProvider` values. Because `UpdateCeremonyDto` extends `PartialType(CreateCeremonyDto)`, the same rule automatically applies to `PATCH /ceremonies/:id` whenever the field is present, so a coordinator can no longer save an empty or unrecognized whitelist through either endpoint.
+- Participant enrollment gains two gates, both served by a single ceremony lookup: the enrolling user's provider must appear in `ceremony.authProviders` (403 otherwise), and the ceremony must be `OPENED` (400 otherwise).
+- The ceremony's coordinator bypasses the provider whitelist at enrollment. Coordinators need a participant row to finalize their own ceremony (`storage.service.ts` grants them upload access via `ParticipantStatus.FINALIZING`), so a naive gate would let a coordinator lock themselves out of finalization by configuring a whitelist that excludes their own provider.
+- The enrollment gate reads the user's `provider` from the database rather than from the JWT-embedded user object, so the decision cannot be made on a stale copy of the user record.
+
+## Capabilities
+
+### New Capabilities
+
+- `ceremony-auth-providers`: the per-ceremony auth provider whitelist as a contract — its value shape, and the validation applied when a coordinator sets it on ceremony creation or update.
+- `ceremony-enrollment`: the rules governing who may enroll as a participant in a ceremony — provider whitelist enforcement, ceremony state requirement, coordinator bypass, and the resulting error responses.
+
+### Modified Capabilities
+
+None. `openspec/specs/` currently has no specs, so both capabilities above are new.
+
+## Impact
+
+**Contract (backend)**
+
+- `apps/backend/src/ceremonies/ceremony.model.ts` — `CeremonyAttributes.authProviders` and the `@Column` type change from `object` to `UserProvider[]`; the column stays `DataType.JSON`.
+- `apps/backend/src/ceremonies/dto/create-ceremony.dto.ts` — `@IsObject()` replaced by array + enum validation; Swagger example updated. `UpdateCeremonyDto` inherits the rule.
+- `apps/backend/src/database/diagram.dbml`, `diagram.sql` — replace the placeholder `'check auth providers classes'` note with the actual contract.
+
+**Enforcement (backend)**
+
+- `apps/backend/src/participants/participants.service.ts` — `create()` loads the ceremony and applies the state and provider gates. `ParticipantsModule` already imports `CeremoniesModule` via `forwardRef`, and `CeremoniesModule` exports `CeremoniesService`, so no new wiring is needed there; `UsersModule` must be added to read the enrolling user's provider.
+- `apps/backend/src/participants/participants.controller.ts` — document the new 403 and 400 responses in Swagger.
+
+**CLI**
+
+- `apps/cli/src/ceremonies/declarations.ts` — `authProviders` type on `CeremonyTemplate`, `CeremonyUpdate`, and `Ceremony`; needs a `UserProvider` enum mirroring the backend.
+- `apps/cli/src/ceremonies/utils.ts` — `validateCreateTemplate` and `validateUpdateTemplate` must check a non-empty array of valid providers instead of "must be an object".
+
+**Tests**
+
+- Fixtures in `apps/backend/test/constants.ts`, `apps/backend/test/coordinator.e2e-spec.ts`, `apps/backend/src/ceremonies/ceremonies.service.spec.ts`, `apps/backend/src/ceremonies/ceremonies.controller.spec.ts`, `apps/cli/src/ceremonies/create.spec.ts`.
+- New coverage in `apps/backend/src/participants/participants.service.spec.ts` for allowed provider, denied provider, coordinator bypass, and non-`OPENED` ceremony state.
+
+**Docs**
+
+- `docs/PRD.md` — the flagged enrollment-enforcement item can be checked off.
+- `docs/ARCHITECTURE.md` — the ceremony model row and the "Enforcement at enrollment is not yet implemented" paragraph both need updating.
+
+**Data**
+
+- No DDL migration: the column is JSON before and after, so Sequelize `synchronize` is unaffected. Existing rows still holding the old boolean-map value will be rejected by the fail-closed gate with a clear error rather than silently allowing enrollment; there is no production deployment, and development databases are recreated.
+
+**Not affected**
+
+- Frontend. No component reads `authProviders` and there is no enrollment UI yet.

--- a/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/specs/ceremony-auth-providers/spec.md
+++ b/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/specs/ceremony-auth-providers/spec.md
@@ -1,0 +1,76 @@
+## Purpose
+
+Defines the per-ceremony auth provider whitelist as an explicit contract: which values it may hold, and what the system accepts or rejects when a coordinator sets it while creating or updating a ceremony. Enrollment enforcement of the whitelist is specified separately under `ceremony-enrollment`.
+
+## ADDED Requirements
+
+### Requirement: Whitelist value shape
+
+A ceremony's auth provider whitelist SHALL be a list of auth provider identifiers, where each identifier is one of the auth providers the platform supports for user authentication. The identifiers SHALL be the same values used to record a user's own auth provider, so that a user's provider can be compared to the whitelist without translation.
+
+#### Scenario: Whitelist naming a single provider
+
+- **WHEN** a coordinator creates a ceremony with a whitelist naming only the GitHub provider
+- **THEN** the ceremony is created and its whitelist reads back as a list containing exactly the GitHub provider identifier
+
+#### Scenario: Whitelist naming several providers
+
+- **WHEN** a coordinator creates a ceremony with a whitelist naming the GitHub and Ethereum providers
+- **THEN** the ceremony is created and its whitelist reads back as a list containing exactly those two provider identifiers, and Cardano is absent
+
+#### Scenario: Whitelist value is not a list
+
+- **WHEN** a coordinator submits a ceremony whose whitelist is an object rather than a list, such as the legacy keyed-boolean form
+- **THEN** the request is rejected with a validation error and no ceremony is created
+
+### Requirement: Unknown providers are rejected
+
+The system SHALL reject a ceremony whose whitelist contains any identifier that is not a supported auth provider. A whitelist SHALL NOT be persisted with entries the enrollment gate cannot interpret.
+
+#### Scenario: Whitelist contains an unrecognized identifier
+
+- **WHEN** a coordinator submits a ceremony whose whitelist contains an identifier that does not correspond to a supported auth provider
+- **THEN** the request is rejected with a validation error naming the offending value and no ceremony is created
+
+#### Scenario: Whitelist mixes known and unknown identifiers
+
+- **WHEN** a coordinator submits a ceremony whose whitelist contains one supported provider and one unrecognized identifier
+- **THEN** the request is rejected with a validation error and no ceremony is created, rather than silently keeping only the recognized entry
+
+### Requirement: Whitelist must not be empty
+
+Because enrollment fails closed against the whitelist, an empty whitelist would produce a ceremony that nobody can join. The system SHALL reject an empty whitelist at the point where a coordinator sets it, so the coordinator learns of the mistake immediately rather than discovering it when participants are turned away.
+
+#### Scenario: Ceremony created with an empty whitelist
+
+- **WHEN** a coordinator submits a ceremony whose whitelist is an empty list
+- **THEN** the request is rejected with a validation error and no ceremony is created
+
+#### Scenario: Ceremony created with no whitelist at all
+
+- **WHEN** a coordinator submits a ceremony that omits the whitelist entirely
+- **THEN** the request is rejected with a validation error, because the whitelist is required and has no default
+
+### Requirement: Whitelist rules apply to updates
+
+The same shape, known-provider, and non-empty rules SHALL apply when a coordinator updates an existing ceremony's whitelist. A ceremony that was created with a valid whitelist SHALL NOT be reducible to an invalid one through an update.
+
+#### Scenario: Update narrows the whitelist to a valid subset
+
+- **WHEN** a coordinator updates a ceremony's whitelist from two providers to one supported provider
+- **THEN** the update succeeds and the ceremony's whitelist reads back as the single named provider
+
+#### Scenario: Update sets an empty whitelist
+
+- **WHEN** a coordinator updates a ceremony's whitelist to an empty list
+- **THEN** the request is rejected with a validation error and the ceremony's existing whitelist is left unchanged
+
+#### Scenario: Update introduces an unknown provider
+
+- **WHEN** a coordinator updates a ceremony's whitelist to include an unrecognized identifier
+- **THEN** the request is rejected with a validation error and the ceremony's existing whitelist is left unchanged
+
+#### Scenario: Update leaves the whitelist untouched
+
+- **WHEN** a coordinator updates a ceremony's description without mentioning the whitelist
+- **THEN** the update succeeds and the ceremony's existing whitelist is preserved

--- a/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/specs/ceremony-enrollment/spec.md
+++ b/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/specs/ceremony-enrollment/spec.md
@@ -1,0 +1,109 @@
+## Purpose
+
+Governs who may become a participant in a ceremony: the auth provider whitelist a candidate must satisfy, the ceremony states in which enrollment is accepted, the coordinator's exemption, and the errors returned when enrollment is refused.
+
+## ADDED Requirements
+
+### Requirement: Enrollment is the sole entry point
+
+Becoming a participant in a ceremony SHALL be possible only through the enrollment request. Every rule in this capability therefore governs the complete set of ways a participant record can come into existence, and no other operation — queue assignment, contribution, upload, or timeout recovery — SHALL create a participant that has not passed these checks.
+
+#### Scenario: Queue assignment does not create participants
+
+- **WHEN** the system assigns participants to circuit queues or recovers a timed-out participant
+- **THEN** it operates only on participants that already exist, and no new participant is created
+
+### Requirement: Enrolling user's provider must be whitelisted
+
+A user SHALL be permitted to enroll in a ceremony only if the auth provider recorded on their account appears in that ceremony's auth provider whitelist. Enrollment SHALL fail closed: if the provider is absent from the whitelist, or the whitelist cannot be interpreted as a list of known providers, the request is refused.
+
+The provider used for this comparison SHALL be read from the authoritative user record rather than from a copy carried in the caller's session credentials, so that the decision cannot be made from a stale provider value.
+
+#### Scenario: Provider is whitelisted
+
+- **WHEN** a user whose account provider is GitHub enrolls in an open ceremony whose whitelist includes GitHub
+- **THEN** the participant is created with the initial participant status and contribution step
+
+#### Scenario: Provider is not whitelisted
+
+- **WHEN** a user whose account provider is Ethereum enrolls in an open ceremony whose whitelist names only GitHub
+- **THEN** the request is refused with a forbidden error explaining that the ceremony does not accept that auth provider, and no participant is created
+
+#### Scenario: Whitelist holds a legacy or uninterpretable value
+
+- **WHEN** a user enrolls in an open ceremony whose stored whitelist is not a list of known providers, such as a ceremony persisted under the previous keyed-boolean format
+- **THEN** the request is refused rather than allowed, and no participant is created
+
+#### Scenario: User record is the source of the provider
+
+- **WHEN** a user enrolls in a ceremony
+- **THEN** the provider compared against the whitelist is the one currently stored on the user record, not the one embedded in the caller's session credentials
+
+### Requirement: Ceremony must be open to accept enrollments
+
+A user SHALL be permitted to enroll only while the ceremony is in the open state. Enrollment into a ceremony that has not yet started, is temporarily paused, has stopped accepting contributions, was abandoned, or has already been finalized SHALL be refused.
+
+#### Scenario: Ceremony is open
+
+- **WHEN** a user with a whitelisted provider enrolls in a ceremony that is open
+- **THEN** the participant is created
+
+#### Scenario: Ceremony has not started
+
+- **WHEN** a user enrolls in a ceremony that is still scheduled
+- **THEN** the request is refused with an error stating the ceremony is not accepting enrollments, and no participant is created
+
+#### Scenario: Ceremony is paused
+
+- **WHEN** a user enrolls in a ceremony that is paused
+- **THEN** the request is refused and no participant is created
+
+#### Scenario: Ceremony no longer accepts contributions
+
+- **WHEN** a user enrolls in a ceremony that is closed, canceled, or finalized
+- **THEN** the request is refused and no participant is created
+
+#### Scenario: Ceremony does not exist
+
+- **WHEN** a user enrolls with a ceremony identifier that matches no ceremony
+- **THEN** the request is refused with a not-found error, and the response does not reveal internal error detail
+
+### Requirement: Coordinator is exempt from the provider whitelist
+
+The coordinator who owns the ceremony SHALL be able to enroll regardless of the ceremony's auth provider whitelist. Coordinators require a participant record to carry out finalization, so enforcing the whitelist against them would let a coordinator configure a whitelist that locks them out of finalizing their own ceremony.
+
+Because finalization takes place after the ceremony stops accepting contributions, the coordinator SHALL also be able to enroll while the ceremony is closed, in addition to while it is open. The coordinator SHALL NOT be able to enroll into a canceled or finalized ceremony, where enrollment serves no purpose.
+
+#### Scenario: Coordinator's provider is not whitelisted
+
+- **WHEN** the ceremony's coordinator, whose account provider is GitHub, enrolls in their own open ceremony whose whitelist names only Ethereum
+- **THEN** the participant is created, because the whitelist does not apply to the coordinator
+
+#### Scenario: Coordinator enrolls to finalize a closed ceremony
+
+- **WHEN** the ceremony's coordinator enrolls in their own ceremony that is closed
+- **THEN** the participant is created, so that finalization can proceed
+
+#### Scenario: Non-coordinator cannot use the exemption
+
+- **WHEN** a user who coordinates a different ceremony enrolls in this ceremony with a provider that is not whitelisted
+- **THEN** the request is refused, because the exemption applies only to the coordinator of the ceremony being joined
+
+#### Scenario: Coordinator enrolls in a finalized ceremony
+
+- **WHEN** the ceremony's coordinator enrolls in their own ceremony that is already finalized or was canceled
+- **THEN** the request is refused and no participant is created
+
+### Requirement: Refusals are distinguishable
+
+Enrollment refusals SHALL be reported so that a client can tell the reasons apart: a provider that is not permitted is reported as a forbidden request, a ceremony whose state does not accept enrollments is reported as a bad request, a missing ceremony is reported as not found, and an already-enrolled user is reported as a conflict. Error messages SHALL NOT leak internal error detail or stack traces.
+
+#### Scenario: Provider refusal versus state refusal
+
+- **WHEN** enrollment is refused because the user's provider is not whitelisted, and separately because the ceremony is not open
+- **THEN** the two refusals carry different status codes and messages, so the client can present the correct explanation
+
+#### Scenario: Duplicate enrollment
+
+- **WHEN** a user who is already a participant in a ceremony enrolls in it again
+- **THEN** the request is refused as a conflict and no second participant record is created

--- a/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/tasks.md
+++ b/openspec/changes/archive/2026-07-29-enforce-ceremony-auth-provider-whitelist/tasks.md
@@ -1,0 +1,72 @@
+## 1. Define the `authProviders` contract
+
+- [x] 1.1 Change `CeremonyAttributes.authProviders` and the corresponding `@Column` in `apps/backend/src/ceremonies/ceremony.model.ts` from `object` to `UserProvider[]`, keeping the column type as `DataType.JSON`, and replace the `'check auth providers classes'` comment with a description of the enum-array contract
+- [x] 1.2 Replace `@IsObject()` on `CreateCeremonyDto.authProviders` in `apps/backend/src/ceremonies/dto/create-ceremony.dto.ts` with `@IsArray()`, `@ArrayNotEmpty()`, and `@IsEnum(UserProvider, { each: true })`, and update the `@ApiProperty` to `enum: UserProvider`, `isArray: true` with an example such as `[UserProvider.GITHUB]`
+- [x] 1.3 Confirm no change is needed in `apps/backend/src/ceremonies/ceremonies.service.ts` beyond types — the field is a straight passthrough on create and update
+- [x] 1.4 Update the `authProviders` note in `apps/backend/src/database/diagram.dbml` and the matching column comment in `apps/backend/src/database/diagram.sql` to document the array-of-`UserProvider` contract
+- [x] 1.5 Verify no DDL change is produced: the column stays JSON, so Sequelize `synchronize` is a no-op for it
+
+## 2. Migrate existing backend fixtures to the new shape
+
+- [x] 2.1 Update `authProviders` in `apps/backend/test/constants.ts` from `{ github: true }` to `[UserProvider.GITHUB]`
+- [x] 2.2 Update the `authProviders` assertions in `apps/backend/test/coordinator.e2e-spec.ts` for the array shape
+- [x] 2.3 Update `authProviders` in the fixtures and expectations in `apps/backend/src/ceremonies/ceremonies.service.spec.ts` and `apps/backend/src/ceremonies/ceremonies.controller.spec.ts`
+- [x] 2.4 Run the ceremonies unit tests and confirm they pass against the new contract
+
+## 3. Cover the whitelist validation rules
+
+- [x] 3.1 Add DTO validation tests for `POST /ceremonies` covering: valid single provider, valid multiple providers, empty array rejected, unknown identifier rejected, mixed known/unknown rejected, legacy `{ github: true }` object rejected, and field omitted entirely rejected
+- [x] 3.2 Add tests confirming the same rules apply to `PATCH /ceremonies/:id` when `authProviders` is present, and that omitting the field leaves the stored whitelist untouched
+
+## 4. Wire the enrollment dependencies
+
+- [x] 4.1 Add `UsersModule` to the `imports` of `apps/backend/src/participants/participants.module.ts` (use `forwardRef` only if a circular import appears)
+- [x] 4.2 Inject `CeremoniesService` and `UsersService` into `ParticipantsService`, matching the existing `forwardRef`/`Inject` style used for `CircuitsService` and `ContributionsService`
+- [x] 4.3 Confirm the backend still boots with the new dependency graph before adding logic
+
+## 5. Enforce the gates at enrollment
+
+- [x] 5.1 In `ParticipantsService.create()`, load the ceremony via `CeremoniesService` before creating the participant, and surface a not-found error when it does not exist
+- [x] 5.2 Determine whether the enrolling user is the ceremony's coordinator using the existing `CeremoniesService.findCoordinatorOfCeremony` / `isCoordinator` path
+- [x] 5.3 Apply the state gate: allow `OPENED` for everyone, additionally allow `CLOSED` for the coordinator, and reject `SCHEDULED`, `PAUSED`, `CANCELED`, and `FINALIZED` with a `BadRequestException`
+- [x] 5.4 Apply the provider gate for non-coordinators: read the enrolling user's `provider` from the user record (not from the JWT-embedded user), and reject with a `ForbiddenException` when it is absent from `ceremony.authProviders`
+- [x] 5.5 Make the provider gate fail closed when `authProviders` is not an interpretable array of known providers, so ceremonies persisted in the legacy format deny rather than admit
+- [x] 5.6 Keep the existing `handleErrors` behaviour intact: the new `ForbiddenException` and `BadRequestException` must propagate as thrown rather than being remapped to a generic 500
+- [x] 5.7 Add TSDoc to `create()` describing the two gates and the coordinator exemption
+
+## 6. Document the new responses
+
+- [x] 6.1 Add `@ApiResponse` entries for 403 (auth provider not permitted), 404 (ceremony not found), and 409 (already enrolled) to the `create` handler in `apps/backend/src/participants/participants.controller.ts`, and clarify the existing 400 description to mention ceremony state
+- [x] 6.2 Update the `CreateParticipantDto` TSDoc to note that enrollment is subject to the ceremony's auth provider whitelist and state
+
+## 7. Test the enrollment gates
+
+- [x] 7.1 Add `apps/backend/src/participants/participants.service.spec.ts` cases for a whitelisted provider enrolling successfully into an `OPENED` ceremony
+- [x] 7.2 Add cases for a non-whitelisted provider rejected with 403, and for a legacy/uninterpretable whitelist rejected rather than allowed
+- [x] 7.3 Add cases for each non-enrollable state (`SCHEDULED`, `PAUSED`, `CLOSED`, `CANCELED`, `FINALIZED`) rejected for a non-coordinator, and for a missing ceremony rejected as not found
+- [x] 7.4 Add coordinator cases: bypasses a whitelist that excludes their provider, may enroll while `CLOSED`, and is still rejected for `CANCELED` and `FINALIZED`
+- [x] 7.5 Add a case proving the exemption is scoped to the ceremony being joined — a coordinator of a different ceremony with a non-whitelisted provider is rejected
+- [x] 7.6 Add a case asserting the provider is read from the user record, so a stale provider in the session credentials cannot influence the decision
+- [x] 7.7 Extend the e2e coverage so a participant enrolls into an `OPENED` ceremony whose whitelist includes their provider, and is refused when it does not
+
+## 8. Update the CLI to the new template format
+
+- [x] 8.1 Add a `UserProvider` enum to `apps/cli/src/ceremonies/declarations.ts`, mirroring the backend enum as `CeremonyType` and `CeremonyState` already are
+- [x] 8.2 Change `authProviders` on `CeremonyTemplate`, `CeremonyUpdate`, and `Ceremony` in `apps/cli/src/ceremonies/declarations.ts` from `Record<string, boolean>` to `UserProvider[]`
+- [x] 8.3 Add an `isValidUserProvider` helper to `apps/cli/src/ceremonies/utils.ts` alongside the existing `isValidCeremonyType` / `isValidCeremonyState` helpers
+- [x] 8.4 Replace the `authProviders` check in `validateCreateTemplate` with a non-empty-array-of-valid-providers check whose error message lists the accepted values
+- [x] 8.5 Apply the same check in `validateUpdateTemplate`, keeping it conditional on the field being present
+- [x] 8.6 Update the `authProviders` fixtures in `apps/cli/src/ceremonies/create.spec.ts` and add validator tests for empty array, unknown provider, and the rejected legacy object form
+
+## 9. Refresh the documentation
+
+- [x] 9.1 Check off the auth provider whitelist enforcement item in `docs/PRD.md` and remove its ⚠️ risk marker
+- [x] 9.2 Update the Ceremony model row in `docs/ARCHITECTURE.md` to describe `authProviders` as an array of `UserProvider` values
+- [x] 9.3 Rewrite the provider-whitelist paragraph in `docs/ARCHITECTURE.md` to state that enrollment enforcement is implemented, describe the fail-closed behaviour and coordinator exemption, and note that the whitelist remains mutable mid-ceremony with already-enrolled participants grandfathered
+
+## 10. Verify
+
+- [x] 10.1 Run the backend unit tests and the CLI tests
+- [x] 10.2 Run the backend e2e suite against the test database
+- [x] 10.3 Run `pnpm lint` and `pnpm prettier:fix` at the root and resolve any findings
+- [x] 10.4 Manually confirm the coordinator finalization path still works end to end: coordinator enrolls, reaches `FINALIZING`, and retains storage upload access

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,31 @@
+schema: spec-driven
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours
+
+# Per-operation guidance (optional)
+# Add advisory guidance for how apply and archive work should be conducted.
+# This is separate from artifact rules above.
+# Example:
+#   operations:
+#     apply:
+#       guidance:
+#         - Keep test summaries concise
+#     archive:
+#       guidance:
+#         - Summarize the archive outcome before finishing

--- a/openspec/specs/ceremony-auth-providers/spec.md
+++ b/openspec/specs/ceremony-auth-providers/spec.md
@@ -1,0 +1,78 @@
+# ceremony-auth-providers Specification
+
+## Purpose
+
+Defines the per-ceremony auth provider whitelist as an explicit contract: which values it may hold, and what the system accepts or rejects when a coordinator sets it while creating or updating a ceremony. Enrollment enforcement of the whitelist is specified separately under `ceremony-enrollment`.
+
+## Requirements
+
+### Requirement: Whitelist value shape
+
+A ceremony's auth provider whitelist SHALL be a list of auth provider identifiers, where each identifier is one of the auth providers the platform supports for user authentication. The identifiers SHALL be the same values used to record a user's own auth provider, so that a user's provider can be compared to the whitelist without translation.
+
+#### Scenario: Whitelist naming a single provider
+
+- **WHEN** a coordinator creates a ceremony with a whitelist naming only the GitHub provider
+- **THEN** the ceremony is created and its whitelist reads back as a list containing exactly the GitHub provider identifier
+
+#### Scenario: Whitelist naming several providers
+
+- **WHEN** a coordinator creates a ceremony with a whitelist naming the GitHub and Ethereum providers
+- **THEN** the ceremony is created and its whitelist reads back as a list containing exactly those two provider identifiers, and Cardano is absent
+
+#### Scenario: Whitelist value is not a list
+
+- **WHEN** a coordinator submits a ceremony whose whitelist is an object rather than a list, such as the legacy keyed-boolean form
+- **THEN** the request is rejected with a validation error and no ceremony is created
+
+### Requirement: Unknown providers are rejected
+
+The system SHALL reject a ceremony whose whitelist contains any identifier that is not a supported auth provider. A whitelist SHALL NOT be persisted with entries the enrollment gate cannot interpret.
+
+#### Scenario: Whitelist contains an unrecognized identifier
+
+- **WHEN** a coordinator submits a ceremony whose whitelist contains an identifier that does not correspond to a supported auth provider
+- **THEN** the request is rejected with a validation error naming the offending value and no ceremony is created
+
+#### Scenario: Whitelist mixes known and unknown identifiers
+
+- **WHEN** a coordinator submits a ceremony whose whitelist contains one supported provider and one unrecognized identifier
+- **THEN** the request is rejected with a validation error and no ceremony is created, rather than silently keeping only the recognized entry
+
+### Requirement: Whitelist must not be empty
+
+Because enrollment fails closed against the whitelist, an empty whitelist would produce a ceremony that nobody can join. The system SHALL reject an empty whitelist at the point where a coordinator sets it, so the coordinator learns of the mistake immediately rather than discovering it when participants are turned away.
+
+#### Scenario: Ceremony created with an empty whitelist
+
+- **WHEN** a coordinator submits a ceremony whose whitelist is an empty list
+- **THEN** the request is rejected with a validation error and no ceremony is created
+
+#### Scenario: Ceremony created with no whitelist at all
+
+- **WHEN** a coordinator submits a ceremony that omits the whitelist entirely
+- **THEN** the request is rejected with a validation error, because the whitelist is required and has no default
+
+### Requirement: Whitelist rules apply to updates
+
+The same shape, known-provider, and non-empty rules SHALL apply when a coordinator updates an existing ceremony's whitelist. A ceremony that was created with a valid whitelist SHALL NOT be reducible to an invalid one through an update.
+
+#### Scenario: Update narrows the whitelist to a valid subset
+
+- **WHEN** a coordinator updates a ceremony's whitelist from two providers to one supported provider
+- **THEN** the update succeeds and the ceremony's whitelist reads back as the single named provider
+
+#### Scenario: Update sets an empty whitelist
+
+- **WHEN** a coordinator updates a ceremony's whitelist to an empty list
+- **THEN** the request is rejected with a validation error and the ceremony's existing whitelist is left unchanged
+
+#### Scenario: Update introduces an unknown provider
+
+- **WHEN** a coordinator updates a ceremony's whitelist to include an unrecognized identifier
+- **THEN** the request is rejected with a validation error and the ceremony's existing whitelist is left unchanged
+
+#### Scenario: Update leaves the whitelist untouched
+
+- **WHEN** a coordinator updates a ceremony's description without mentioning the whitelist
+- **THEN** the update succeeds and the ceremony's existing whitelist is preserved

--- a/openspec/specs/ceremony-enrollment/spec.md
+++ b/openspec/specs/ceremony-enrollment/spec.md
@@ -1,0 +1,111 @@
+# ceremony-enrollment Specification
+
+## Purpose
+
+Governs who may become a participant in a ceremony: the auth provider whitelist a candidate must satisfy, the ceremony states in which enrollment is accepted, the coordinator's exemption, and the errors returned when enrollment is refused.
+
+## Requirements
+
+### Requirement: Enrollment is the sole entry point
+
+Becoming a participant in a ceremony SHALL be possible only through the enrollment request. Every rule in this capability therefore governs the complete set of ways a participant record can come into existence, and no other operation — queue assignment, contribution, upload, or timeout recovery — SHALL create a participant that has not passed these checks.
+
+#### Scenario: Queue assignment does not create participants
+
+- **WHEN** the system assigns participants to circuit queues or recovers a timed-out participant
+- **THEN** it operates only on participants that already exist, and no new participant is created
+
+### Requirement: Enrolling user's provider must be whitelisted
+
+A user SHALL be permitted to enroll in a ceremony only if the auth provider recorded on their account appears in that ceremony's auth provider whitelist. Enrollment SHALL fail closed: if the provider is absent from the whitelist, or the whitelist cannot be interpreted as a list of known providers, the request is refused.
+
+The provider used for this comparison SHALL be read from the authoritative user record rather than from a copy carried in the caller's session credentials, so that the decision cannot be made from a stale provider value.
+
+#### Scenario: Provider is whitelisted
+
+- **WHEN** a user whose account provider is GitHub enrolls in an open ceremony whose whitelist includes GitHub
+- **THEN** the participant is created with the initial participant status and contribution step
+
+#### Scenario: Provider is not whitelisted
+
+- **WHEN** a user whose account provider is Ethereum enrolls in an open ceremony whose whitelist names only GitHub
+- **THEN** the request is refused with a forbidden error explaining that the ceremony does not accept that auth provider, and no participant is created
+
+#### Scenario: Whitelist holds a legacy or uninterpretable value
+
+- **WHEN** a user enrolls in an open ceremony whose stored whitelist is not a list of known providers, such as a ceremony persisted under the previous keyed-boolean format
+- **THEN** the request is refused rather than allowed, and no participant is created
+
+#### Scenario: User record is the source of the provider
+
+- **WHEN** a user enrolls in a ceremony
+- **THEN** the provider compared against the whitelist is the one currently stored on the user record, not the one embedded in the caller's session credentials
+
+### Requirement: Ceremony must be open to accept enrollments
+
+A user SHALL be permitted to enroll only while the ceremony is in the open state. Enrollment into a ceremony that has not yet started, is temporarily paused, has stopped accepting contributions, was abandoned, or has already been finalized SHALL be refused.
+
+#### Scenario: Ceremony is open
+
+- **WHEN** a user with a whitelisted provider enrolls in a ceremony that is open
+- **THEN** the participant is created
+
+#### Scenario: Ceremony has not started
+
+- **WHEN** a user enrolls in a ceremony that is still scheduled
+- **THEN** the request is refused with an error stating the ceremony is not accepting enrollments, and no participant is created
+
+#### Scenario: Ceremony is paused
+
+- **WHEN** a user enrolls in a ceremony that is paused
+- **THEN** the request is refused and no participant is created
+
+#### Scenario: Ceremony no longer accepts contributions
+
+- **WHEN** a user enrolls in a ceremony that is closed, canceled, or finalized
+- **THEN** the request is refused and no participant is created
+
+#### Scenario: Ceremony does not exist
+
+- **WHEN** a user enrolls with a ceremony identifier that matches no ceremony
+- **THEN** the request is refused with a not-found error, and the response does not reveal internal error detail
+
+### Requirement: Coordinator is exempt from the provider whitelist
+
+The coordinator who owns the ceremony SHALL be able to enroll regardless of the ceremony's auth provider whitelist. Coordinators require a participant record to carry out finalization, so enforcing the whitelist against them would let a coordinator configure a whitelist that locks them out of finalizing their own ceremony.
+
+Because finalization takes place after the ceremony stops accepting contributions, the coordinator SHALL also be able to enroll while the ceremony is closed, in addition to while it is open. The coordinator SHALL NOT be able to enroll into a canceled or finalized ceremony, where enrollment serves no purpose.
+
+#### Scenario: Coordinator's provider is not whitelisted
+
+- **WHEN** the ceremony's coordinator, whose account provider is GitHub, enrolls in their own open ceremony whose whitelist names only Ethereum
+- **THEN** the participant is created, because the whitelist does not apply to the coordinator
+
+#### Scenario: Coordinator enrolls to finalize a closed ceremony
+
+- **WHEN** the ceremony's coordinator enrolls in their own ceremony that is closed
+- **THEN** the participant is created, so that finalization can proceed
+
+#### Scenario: Non-coordinator cannot use the exemption
+
+- **WHEN** a user who coordinates a different ceremony enrolls in this ceremony with a provider that is not whitelisted
+- **THEN** the request is refused, because the exemption applies only to the coordinator of the ceremony being joined
+
+#### Scenario: Coordinator enrolls in a finalized ceremony
+
+- **WHEN** the ceremony's coordinator enrolls in their own ceremony that is already finalized or was canceled
+- **THEN** the request is refused and no participant is created
+
+### Requirement: Refusals are distinguishable
+
+Enrollment refusals SHALL be reported so that a client can tell the reasons apart: a provider that is not permitted is reported as a forbidden request, a ceremony whose state does not accept enrollments is reported as a bad request, a missing ceremony is reported as not found, and an already-enrolled user is reported as a conflict. Error messages SHALL NOT leak internal error detail or stack traces.
+
+#### Scenario: Provider refusal versus state refusal
+
+- **WHEN** enrollment is refused because the user's provider is not whitelisted, and separately because the ceremony is not open
+- **THEN** the two refusals carry different status codes and messages, so the client can present the correct explanation
+
+#### Scenario: Duplicate enrollment
+
+- **WHEN** a user who is already a participant in a ceremony enrolls in it again
+- **THEN** the request is refused as a conflict and no second participant record is created

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,22 @@ packages:
   - packages/*
   - apps/*
 
+allowBuilds:
+  "@nestjs/core": true
+  "@scarf/scarf": true
+  "@swc/core": true
+  aws-sdk: true
+  bufferutil: true
+  chacha-native: true
+  core-js: true
+  core-js-pure: true
+  esbuild: true
+  node-datachannel: true
+  nx: true
+  unrs-resolver: true
+  utf-8-validate: true
+  utp-native: true
+
 ignoredBuiltDependencies:
   - "@nestjs/core"
   - "@scarf/scarf"


### PR DESCRIPTION
Replace the legacy keyed-boolean authProviders shape with a validated UserProvider[] on ceremonies, enforce provider and ceremony-state gates when participants enroll (with coordinator bypass), and align CLI, tests, docs, and OpenSpec with the new contract.